### PR TITLE
Enable tenant layer for mia in sandbox

### DIFF
--- a/clusters/sandbox/kustomization.yaml
+++ b/clusters/sandbox/kustomization.yaml
@@ -7,5 +7,5 @@ resources:
   # Big Bang platform bundle
   - ../../bigbang
 
-  # Tenant applications (uncomment when ready)
-  # - ../../../tenants
+  # Tenant applications
+  - ../../tenants

--- a/tenants/kustomization.yaml
+++ b/tenants/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - mia


### PR DESCRIPTION
## Summary
- add tenants root kustomization with mia resource
- enable tenants layer in sandbox cluster kustomization

## Validation
- kubectl kustomize clusters/sandbox renders including mia resources

## Notes
- this only activates tenant reconciliation wiring; cluster mutation remains **Run manually by human**.