### PR TITLE
Fix Kyverno verifyImages credentials schema

### DIFF
--- a/platform/policies/kyverno/require-signed-ghcr-images.yaml
+++ b/platform/policies/kyverno/require-signed-ghcr-images.yaml
@@ -17,8 +17,6 @@ spec:
             - "ghcr.io/zavestudios/*"
           mutateDigest: false
           imageRegistryCredentials:
-            helpers:
-              - github
             secrets:
               - ghcr-secret
           attestors:


### PR DESCRIPTION
## Summary
- remove unsupported `imageRegistryCredentials.helpers` field
- keep `imageRegistryCredentials.secrets: [ghcr-secret]`

## Why
Flux reconcile is currently blocked by Kyverno CRD schema validation error:
`.imageRegistryCredentials.helpers: field not declared in schema`

## Impact
- unblocks Flux reconciliation
- allows kyverno namespace sealed secret and other pending changes to apply
