### PR TITLE
Update mia deployment digest to signed 66888bb image

### DIFF
--- a/tenants/mia/deployment.yaml
+++ b/tenants/mia/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       - name: ghcr-secret
       containers:
       - name: mia
-        image: ghcr.io/zavestudios/mia:sha-6257797@sha256:66888bbfdb85951a743858232c02f11f49868267966bf6c92c9c2f6eaf44fed0
+        image: ghcr.io/zavestudios/mia@sha256:66888bbfdb85951a743858232c02f11f49868267966bf6c92c9c2f6eaf44fed0
         ports:
         - containerPort: 18789
           name: http


### PR DESCRIPTION
## Summary
- update tenants/mia/deployment.yaml to digest sha256:66888bbfdb85951a743858232c02f11f49868267966bf6c92c9c2f6eaf44fed0

## Why
- move mia to signed digest produced by main build 
- satisfy Kyverno image signature verification

## Expected Outcome
- deployment uses signed image digest
- signature policy violation () should clear for new pods