### PR TITLE
Update mia deployment to signed digest 1f7cc9

### DIFF
--- a/tenants/mia/deployment.yaml
+++ b/tenants/mia/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       - name: ghcr-secret
       containers:
       - name: mia
-        image: ghcr.io/zavestudios/mia@sha256:66888bbfdb85951a743858232c02f11f49868267966bf6c92c9c2f6eaf44fed0
+        image: ghcr.io/zavestudios/mia@sha256:1f7cc91dff05119477109ba3514a020a371e017fb31af14c83f5e71317e5f7f9
         ports:
         - containerPort: 18789
           name: http


### PR DESCRIPTION
## Summary
- update mia deployment image digest to sha256:1f7cc91dff05119477109ba3514a020a371e017fb31af14c83f5e71317e5f7f9

## Why
- previous digest was being reported by Kyverno as unsigned ()
- this digest corresponds to the published cosign  artifact

## Expected Outcome
- Kyverno verifyImages should find signature material for new pods