### PR TITLE
Increase mia memory for Node OOM stability

### DIFF
--- a/tenants/mia/deployment.yaml
+++ b/tenants/mia/deployment.yaml
@@ -38,12 +38,14 @@ spec:
         env:
         - name: NODE_ENV
           value: "production"
+        - name: NODE_OPTIONS
+          value: "--max-old-space-size=768"
         resources:
           requests:
-            memory: "256Mi"
+            memory: "512Mi"
             cpu: "250m"
           limits:
-            memory: "512Mi"
+            memory: "1Gi"
             cpu: "500m"
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Summary
- add NODE_OPTIONS=--max-old-space-size=768
- increase memory request/limit from 256Mi/512Mi to 512Mi/1Gi

## Why
Mia container is crashing with Node OOM during startup:


## Expected Outcome
- mia should stop crashing on startup due to heap exhaustion
- readiness/liveness can evaluate a stable process