### PR TITLE
Temporarily disable mia probes for bootstrap stability

### DIFF
--- a/tenants/mia/deployment.yaml
+++ b/tenants/mia/deployment.yaml
@@ -47,15 +47,3 @@ spec:
           limits:
             memory: "1Gi"
             cpu: "500m"
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 18789
-          initialDelaySeconds: 30
-          periodSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 18789
-          initialDelaySeconds: 15
-          periodSeconds: 5


### PR DESCRIPTION
## Summary
- remove readinessProbe and livenessProbe from mia deployment

## Why
- current probes are causing restart loop ( on /health)
- bootstrap objective is to keep the container running for first stable deploy

## Follow-up
- reintroduce probes after validating actual health endpoint/port behavior
- add startupProbe + tuned readiness/liveness thresholds