### PR TITLE
Make Flux platform-only for tenant ownership boundary

### DIFF
--- a/clusters/sandbox/kustomization.yaml
+++ b/clusters/sandbox/kustomization.yaml
@@ -7,5 +7,4 @@ resources:
   # Big Bang platform bundle
   - ../../bigbang
 
-  # Tenant applications
-  - ../../tenants
+  # Tenant workloads are reconciled by ArgoCD Applications managed under platform/.


### PR DESCRIPTION
## Summary
- remove direct tenant apply (../../tenants) from sandbox Flux entrypoint
- keep Argo Application registration under platform/argocd/applications

## Why
This resolves dual-controller ownership drift where Flux and Argo both mutated tenant runtime resources.

## Expected Outcome
- Flux manages platform/infrastructure and Argo app registrations
- Argo manages tenant workload resources under tenants/*
- reduced rollout churn and cleaner managed fields on tenant Deployments
