### PR TITLE
Add canary rollout artifacts for mia and reusable tenant template

### DIFF
--- a/docs/canary-rollout-pattern.md
+++ b/docs/canary-rollout-pattern.md
@@ -1,0 +1,49 @@
+# Canary Rollout Pattern (Formation)
+
+This document defines a practical canary workflow for tenant workloads during Formation.
+
+This is an operational pattern, not contract-level `spec.delivery: canary` implementation.
+
+## Purpose
+
+- Validate candidate digests without destabilizing stable service.
+- Collect reusable rollout artifacts for future tenant workloads.
+- Keep promotion and rollback Git-driven.
+
+## Ownership Model
+
+- ArgoCD reconciles tenant workload resources under `tenants/*`.
+- FluxCD reconciles platform resources and Argo Application registrations.
+
+## Current Reference Implementation
+
+- Stable workload: `tenants/mia/deployment.yaml`
+- Canary workload: `tenants/mia/canary-deployment.yaml`
+- Canary ingress host: `mia-canary-sandbox.zavestudios.com`
+
+## Rollout Procedure
+
+1. Pin stable deployment to known-good digest.
+2. Set canary deployment digest to candidate signed digest.
+3. Scale canary to `1` replica.
+4. Validate canary runtime:
+   - pod starts without crash loops
+   - policy checks pass
+   - endpoint responds via canary ingress
+5. Promote:
+   - copy candidate digest to stable deployment
+   - keep canary at `0` (or delete canary resources)
+6. Roll back:
+   - restore prior stable digest
+   - set canary to `0`
+
+## Validation Checklist
+
+- `kubectl -n <ns> get pods` shows stable and canary pod health as expected.
+- No ongoing `PolicyViolation` for signature checks on candidate digest.
+- Restart counts remain stable during validation.
+- Stable service remains unaffected while canary is tested.
+
+## Reusable Template
+
+Use `tenants/_templates/canary/` to scaffold canary manifests for other workloads.

--- a/tenants/_templates/canary/README.md
+++ b/tenants/_templates/canary/README.md
@@ -1,0 +1,17 @@
+# Tenant Canary Template
+
+Use these manifests to add an isolated canary path for any tenant workload.
+
+## Template Variables
+
+- `__WORKLOAD__` - canonical workload name (for example `mia`)
+- `__NAMESPACE__` - namespace (often same as workload)
+- `__DIGEST__` - candidate image digest (`sha256:...`)
+- `__VERSION__` - version label value (for example `sha-6257797`)
+- `__CANARY_HOST__` - host for canary ingress (for example `mia-canary-sandbox.zavestudios.com`)
+
+## Notes
+
+- Template defaults should start with `replicas: 0` for safe activation.
+- Increase canary replicas to `1` only during validation.
+- Keep stable and canary services separate to avoid traffic mixing.

--- a/tenants/_templates/canary/canary-deployment.yaml
+++ b/tenants/_templates/canary/canary-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: __WORKLOAD__-canary
+  namespace: __NAMESPACE__
+  labels:
+    app: __WORKLOAD__-canary
+    app.kubernetes.io/name: __WORKLOAD__
+    app.kubernetes.io/component: canary
+    app.kubernetes.io/version: __VERSION__
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: __WORKLOAD__-canary
+  template:
+    metadata:
+      labels:
+        app: __WORKLOAD__-canary
+        app.kubernetes.io/name: __WORKLOAD__
+        app.kubernetes.io/component: canary
+        app.kubernetes.io/version: __VERSION__
+    spec:
+      imagePullSecrets:
+      - name: ghcr-secret
+      containers:
+      - name: __WORKLOAD__
+        image: ghcr.io/zavestudios/__WORKLOAD__@__DIGEST__

--- a/tenants/_templates/canary/canary-ingress.yaml
+++ b/tenants/_templates/canary/canary-ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: __WORKLOAD__-canary
+  namespace: __NAMESPACE__
+  labels:
+    app: __WORKLOAD__-canary
+    app.kubernetes.io/name: __WORKLOAD__
+    app.kubernetes.io/component: canary
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - __CANARY_HOST__
+    secretName: __WORKLOAD__-canary-tls
+  rules:
+  - host: __CANARY_HOST__
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: __WORKLOAD__-canary
+            port:
+              number: 80

--- a/tenants/_templates/canary/canary-service.yaml
+++ b/tenants/_templates/canary/canary-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: __WORKLOAD__-canary
+  namespace: __NAMESPACE__
+  labels:
+    app: __WORKLOAD__-canary
+    app.kubernetes.io/name: __WORKLOAD__
+    app.kubernetes.io/component: canary
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 18789
+    protocol: TCP
+    name: http
+  selector:
+    app: __WORKLOAD__-canary

--- a/tenants/mia/canary-deployment.yaml
+++ b/tenants/mia/canary-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mia-canary
+  namespace: mia
+  labels:
+    app: mia-canary
+    app.kubernetes.io/name: mia
+    app.kubernetes.io/component: canary
+    app.kubernetes.io/version: sha-161c5ed
+    zave.io/workload: mia
+spec:
+  # Canary is disabled by default; set to 1 during canary validation.
+  replicas: 0
+  selector:
+    matchLabels:
+      app: mia-canary
+  template:
+    metadata:
+      labels:
+        app: mia-canary
+        app.kubernetes.io/name: mia
+        app.kubernetes.io/component: canary
+        app.kubernetes.io/version: sha-161c5ed
+        zave.io/workload: mia
+    spec:
+      imagePullSecrets:
+      - name: ghcr-secret
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+      - name: mia
+        securityContext:
+          runAsNonRoot: true
+        image: ghcr.io/zavestudios/mia@sha256:bfed1742f7885dfd826fd7fe83ce38c518a2b8549efd3a0e5ed3b7a1f56bef04
+        ports:
+        - containerPort: 18789
+          name: http
+          protocol: TCP
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: NODE_OPTIONS
+          value: "--max-old-space-size=768"
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"

--- a/tenants/mia/canary-ingress.yaml
+++ b/tenants/mia/canary-ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mia-canary
+  namespace: mia
+  labels:
+    app: mia-canary
+    app.kubernetes.io/name: mia
+    app.kubernetes.io/component: canary
+    zave.io/workload: mia
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - mia-canary-sandbox.zavestudios.com
+    secretName: mia-canary-tls
+  rules:
+  - host: mia-canary-sandbox.zavestudios.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: mia-canary
+            port:
+              number: 80

--- a/tenants/mia/canary-service.yaml
+++ b/tenants/mia/canary-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mia-canary
+  namespace: mia
+  labels:
+    app: mia-canary
+    app.kubernetes.io/name: mia
+    app.kubernetes.io/component: canary
+    zave.io/workload: mia
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 18789
+    protocol: TCP
+    name: http
+  selector:
+    app: mia-canary

--- a/tenants/mia/kustomization.yaml
+++ b/tenants/mia/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - canary-deployment.yaml
+  - canary-service.yaml
+  - canary-ingress.yaml
 
 commonLabels:
   zave.io/workload: mia


### PR DESCRIPTION
## Summary
- add canary manifests for mia (canary-deployment/service/ingress)
- default canary replicas to 0 for safe activation
- add reusable canary scaffold under tenants/_templates/canary
- add formation-phase rollout guide in docs/canary-rollout-pattern.md

## Why
- validate candidate digests safely without destabilizing stable mia
- capture reusable rollout artifacts for other tenant workloads

## Notes
- this is an operational pattern, not contract-level spec.delivery: canary implementation
- tenant runtime ownership remains Argo-managed
