### PR TITLE
Relocate llm platform docs to service repo

### DIFF
--- a/docs/llm-platform-migration-plan.md
+++ b/docs/llm-platform-migration-plan.md
@@ -1,0 +1,27 @@
+# LLM Platform Migration Plan
+
+This document moved to the `llm-platform` repository.
+
+Canonical location:
+
+- https://github.com/zavestudios/llm-platform/blob/main/docs/MIGRATION_PLAN.md
+
+`gitops` remains the deployment-state authority for manifests and rollout state.
+Architecture ownership for the shared LLM platform now lives with the platform service itself.
+
+Every phase should preserve the previous working path until validation is complete.
+
+## Recommended Next Changes
+
+1. Update `mia` to depend on `LLM_BASE_URL` instead of `OLLAMA_HOST` plus direct provider assumptions.
+2. Create shared GitOps manifests for `llm-gateway`.
+3. Extend `oracle` job types around gateway-backed LLM execution.
+4. Remove tenant-local `Ollama` only after Phase 1 is stable.
+5. Add `vLLM` last, not first.
+
+## Non-Goals
+
+- Replacing `mia` as the chat/channel gateway
+- Replacing `oracle` with model-serving software
+- Treating `k8s-mcp` as part of the inference plane
+- Building a full self-hosted stack before demand is proven

--- a/docs/mia-ollama-heartbeat.md
+++ b/docs/mia-ollama-heartbeat.md
@@ -1,5 +1,13 @@
 # Mia Ollama Heartbeat Deployment
 
+This document describes the current tenant-scoped pattern.
+It is not the target long-term architecture.
+For the shared-platform migration target, see the `llm-platform` repository:
+
+- migration plan: https://github.com/zavestudios/llm-platform/blob/main/docs/MIGRATION_PLAN.md
+- architecture docs: https://github.com/zavestudios/llm-platform/blob/main/docs/ARCHITECTURE.md
+- draw.io diagram: https://github.com/zavestudios/llm-platform/blob/main/docs/ARCHITECTURE.drawio
+
 This document captures the tenant-scoped Ollama pattern used by `mia` for heartbeat cost optimization.
 
 ## Scope and Governance


### PR DESCRIPTION
## Summary
- replace the local `gitops` migration doc with a pointer to the canonical copy in `llm-platform`
- update the Mia Ollama note to point to the canonical architecture and migration docs

## Why
The LLM architecture and migration plan are now owned by the shared platform-service repository.
`gitops` should keep deployment-state concerns and links, not duplicate architectural authority.
