### PR TITLE
Configure Vault auto-unseal with AWS KMS

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -206,6 +206,11 @@ addons:
               ui = true
               api_addr = "http://vault.vault.svc.cluster.local:8200"
 
+              seal "awskms" {
+                region     = "us-west-2"
+                kms_key_id = "alias/zavestudios-onprem-vault-auto-unseal"
+              }
+
               listener "tcp" {
                 tls_disable = 1
                 address = "[::]:8200"
@@ -225,6 +230,13 @@ addons:
           serviceAccount:
             create: true
             automountServiceAccountToken: false
+          extraSecretEnvironmentVars:
+            - envName: AWS_ACCESS_KEY_ID
+              secretName: vault-aws-auto-unseal
+              secretKey: AWS_ACCESS_KEY_ID
+            - envName: AWS_SECRET_ACCESS_KEY
+              secretName: vault-aws-auto-unseal
+              secretKey: AWS_SECRET_ACCESS_KEY
           # Add required labels for Kyverno policies
           statefulSet:
             annotations:

--- a/platform/vault/kustomization.yaml
+++ b/platform/vault/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - vault-aws-auto-unseal.sealed-secret.yaml
   - vault-reader-serviceaccount.yaml
   - clustersecretstore.yaml

--- a/platform/vault/vault-aws-auto-unseal.sealed-secret.yaml
+++ b/platform/vault/vault-aws-auto-unseal.sealed-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: vault-aws-auto-unseal
+  namespace: vault
+  labels:
+    zave.io/component: vault
+spec:
+  encryptedData:
+    AWS_ACCESS_KEY_ID: AgDJwOQnSYzQyAuWLshE63oBtCcXdHAzR11GrupvFbBKonmskKanWlHJv6qeJQ4VB6D75CfpbC2sVMc9fA6G0f0CQOyQTBwvjk+bNlbPC5A9kzZn9JV93Ti9ESQ7vdTG49oiL/lwJ+zWzusmqmp9m3nMkK5y999np9lI7gMi+eq/XXRYpM4J0OYE/sqDaCqTiDzLEiIw2+/CoZH8SEykWkRulmVlNVaC+0haZ1x2UMOkjoDxAj70ypISZkuAFPAA9imKEs45iqSq3svmOBI4HxXx7zcj29vXHFAR9cgPmNFVgcZ8JpH/LbBrZKs+PtfOeN0c3BQusnMNA5TJx4DfGfl5Kiy9YcgToDH9WlMxR1bhe2wUTZrc6vwU/JgyeDuq8BEKZ8NhSwAibVMeX7u9fkNLv2NAdMOcfS8Zxt1gIYGqG+4gl52/32JgnbnpWYFgGxVJK1JuZyQL0xLBoPFLhGgks6XB/7+sMsz09vo/xtbtz0k1INXgrxR+KAkLh7DhOP1HJcUMWi3bTahrGcn9+ZUnwGIfJtDKQL4uV8kFBFXNW6CNfM83oKXg5+YwMQEDAsQK/2HpiJgbULbWpDyvMHSlrB0e29ydWPedX1/gNMz62BEjQ6L/fv0yn5p94Ne1O/r55z7g2geq0eBMIsRyIc0r3rtXWwvG+zDcAZZ7MrzzUisoMINro+z8aOROg26vL8Yzdj0ThNM5nX+TtBNAw1elVDdZfA==
+    AWS_SECRET_ACCESS_KEY: AgAfwTWOYhJXKqAE+oLxVMD94qj2zGYEmvvseFaD0SAXVm2/kg46x2PQuAkA218nwrrNHaGNf/ydtblUA6DIISewN1Su+hwlXZVu0JkoICkgJzQWVJBYdhyP+N78s1TwTAiMTmPO7roKEQcEsZ3QSPxCTBkw1VPYwSf1+81cqeXy4+leLreNXhU9liTLW9eyJ6tObEtQtlr9cl2xBkdeUim/wQakmX+yRPHXOzYSq6AXyBWZDngyzkLPJpSeAkdN0CGKlhxBOYe/exjjc369jjQEbl8dF3hv1DlIpzQvwQB6zVXAJTHEV7Mt+PXK0xV8gkBEzehIBZ6WY5/HnxwCOoXUqfiP1SKjA0L1HKG3R14KDGM5a4jYKQhrW753blS1WuH3A4TiqbJ+KThwrImKbrtI/IHZPcDrm8f6bhDMjwciytJHuwykqHUuSJa1wqCEM3Mylnsj2MSrc6B/gG9//rwbygu2jbtlXoJz2J7+U5ieyn+bvSwXAURZUR3X/CjhR3HZ21ruUr3r8ojgmvmAqWqa3NHeui/4WBuApMtJSzZeBCKlhJkpDH5UoCAUyZdB3A9kjWOXUh6l87IP8qmO2nhbaYiTamPggSUAbm8HLGOTK6aK2Yh5O5mDWyeOQyUNxvSsu+VaqGBybue+W68K6G8ZMcSIRUh7FwUpLGVONl1drHVjG/Q5iTd07aBxLjnBg72ZjLkOx8saR9rDLAsp4Y/6iApEUfPFhJfD8gjlM1fmQIPnCuCQndGh
+  template:
+    metadata:
+      name: vault-aws-auto-unseal
+      namespace: vault
+      labels:
+        zave.io/component: vault
+    type: Opaque


### PR DESCRIPTION
- add AWS KMS auto-unseal config for Vault
- add SealedSecret bootstrap for Vault AWS credentials
- keep Vault ESO integration unchanged
- intended validation: Vault should come back unsealed after restart and vault-kv should recover without manual intervention