### PR TITLE
Rename on-prem hostname surfaces

### DIFF
--- a/bigbang/configmap-backup.yaml
+++ b/bigbang/configmap-backup.yaml
@@ -6,14 +6,14 @@ metadata:
   namespace: bigbang
 data:
   values.yaml: |
-    # Big Bang values for sandbox environment
+    # Big Bang values for on-prem environment
     # Minimal scope: Istio + ArgoCD + Monitoring
     # Disable packages requiring Iron Bank access
 
     # MECHANIC'S NOTE: `enabled=true` causes the BigBang umbrella chart to emit a HelmRelease for the package. 
 
     # Domain configuration - routed via Cloudflare Tunnel
-    domain: sandbox.zavestudios.com
+    domain: on-prem.zavestudios.com
 
     # Override default Iron Bank registry to use public registries
     registryCredentials:

--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -371,7 +371,7 @@ grafana:
     istio:
       grafana:
         hosts:
-          - grafana-sandbox.zavestudios.com  # Single-level subdomain for free SSL
+          - grafana-on-prem.zavestudios.com  # Single-level subdomain for free SSL
     upstream:
       image:
         registry: docker.io
@@ -386,7 +386,7 @@ grafana:
         enabled: false
       grafana.ini:
         server:
-          root_url: https://grafana-sandbox.zavestudios.com
+          root_url: https://grafana-on-prem.zavestudios.com
 
 # Tempo - distributed tracing (disabled due to x86-64-v2 CPU requirement incompatibility)
 tempo:

--- a/docs/canary-rollout-pattern.md
+++ b/docs/canary-rollout-pattern.md
@@ -19,7 +19,7 @@ This is an operational pattern, not contract-level `spec.delivery: canary` imple
 
 - Stable workload: `tenants/mia/deployment.yaml`
 - Canary workload: `tenants/mia/canary-deployment.yaml`
-- Canary ingress host: `mia-canary-sandbox.zavestudios.com`
+- Canary ingress host: `mia-canary-on-prem.zavestudios.com`
 
 ## Rollout Procedure
 

--- a/docs/environment-semantics-plan.md
+++ b/docs/environment-semantics-plan.md
@@ -31,10 +31,10 @@ Before the control-plane rename, the repository used `sandbox` as the active env
   - `sandbox-bigbang`
   - `sandbox-platform-runtime`
 - public and operator-facing hostnames such as:
-  - `mia-sandbox.zavestudios.com`
-  - `mia-canary-sandbox.zavestudios.com`
-  - `grafana-sandbox.zavestudios.com`
-  - `argocd-sandbox.zavestudios.com` in platform docs
+- `mia-on-prem.zavestudios.com`
+- `mia-canary-on-prem.zavestudios.com`
+- `grafana-on-prem.zavestudios.com`
+- `argocd-on-prem.zavestudios.com` in platform docs
 - operator docs and commands that still bootstrap or apply `clusters/sandbox`
 
 Operationally, however, the environment behaves like:
@@ -109,10 +109,10 @@ Manual impact to plan carefully:
 
 Decide whether to rename operator and tenant-facing hosts such as:
 
-- `mia-sandbox.zavestudios.com`
-- `mia-canary-sandbox.zavestudios.com`
-- `grafana-sandbox.zavestudios.com`
-- `argocd-sandbox.zavestudios.com`
+- `mia-on-prem.zavestudios.com`
+- `mia-canary-on-prem.zavestudios.com`
+- `grafana-on-prem.zavestudios.com`
+- `argocd-on-prem.zavestudios.com`
 
 Recommendation:
 

--- a/tenants/_templates/canary/README.md
+++ b/tenants/_templates/canary/README.md
@@ -8,7 +8,7 @@ Use these manifests to add an isolated canary path for any tenant workload.
 - `__NAMESPACE__` - namespace (often same as workload)
 - `__DIGEST__` - candidate image digest (`sha256:...`)
 - `__VERSION__` - version label value (for example `sha-6257797`)
-- `__CANARY_HOST__` - host for canary ingress (for example `mia-canary-sandbox.zavestudios.com`)
+- `__CANARY_HOST__` - host for canary ingress (for example `mia-canary-on-prem.zavestudios.com`)
 
 ## Notes
 

--- a/tenants/mia/canary-ingress.yaml
+++ b/tenants/mia/canary-ingress.yaml
@@ -15,10 +15,10 @@ spec:
   ingressClassName: nginx
   tls:
   - hosts:
-    - mia-canary-sandbox.zavestudios.com
+    - mia-canary-on-prem.zavestudios.com
     secretName: mia-canary-tls
   rules:
-  - host: mia-canary-sandbox.zavestudios.com
+  - host: mia-canary-on-prem.zavestudios.com
     http:
       paths:
       - path: /

--- a/tenants/mia/ingress.yaml
+++ b/tenants/mia/ingress.yaml
@@ -13,10 +13,10 @@ spec:
   ingressClassName: nginx
   tls:
   - hosts:
-    - mia-sandbox.zavestudios.com
+    - mia-on-prem.zavestudios.com
     secretName: mia-tls
   rules:
-  - host: mia-sandbox.zavestudios.com
+  - host: mia-on-prem.zavestudios.com
     http:
       paths:
       - path: /


### PR DESCRIPTION
## Summary

- rename the current on-prem hostname surfaces from `*-sandbox.zavestudios.com` to `*-on-prem.zavestudios.com`
- update Grafana hostname settings and the Big Bang backup values domain
- update `mia` and `mia-canary` ingress hosts
- align repo docs and canary template examples with the on-prem hostname pattern

## Testing

- repo search confirms no remaining `*-sandbox.zavestudios.com` references in `gitops`

## Manual Validation

**Run manually by human**

After merge, verify DNS, ingress, and certificate behavior for the new hosts.

Expected new hosts:

- `grafana-on-prem.zavestudios.com`
- `mia-on-prem.zavestudios.com`
- `mia-canary-on-prem.zavestudios.com`

Cluster checks:

```bash
kubectl -n mia get ingress
kubectl -n mia describe ingress mia
kubectl -n mia describe ingress mia-canary
kubectl -n bigbang get hr grafana
kubectl -n flux-system get kustomization
```

What to verify:

- ingresses render the new `*-on-prem` hosts
- cert-manager issues or updates certificates for the new hosts
- Grafana remains healthy after the hostname change
- Flux reconciliation stays healthy

External checks:

- confirm Cloudflare DNS / routing exists for the new `*-on-prem` hosts
- confirm the old `*-sandbox` hostnames are either retired intentionally or left as temporary compatibility debt
