### PR TITLE
Onboard data-pipelines tenant with ExternalSecret integration

### DIFF
--- a/platform/argocd/applications/data-pipelines.yaml
+++ b/platform/argocd/applications/data-pipelines.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: data-pipelines
+  namespace: argocd
+  labels:
+    zave.io/workload: data-pipelines
+    zave.io/tenant: "true"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/zavestudios/gitops
+    targetRevision: main
+    path: tenants/data-pipelines
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: data-pipelines
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/tenants/data-pipelines/data-pipelines-db.externalsecret.yaml
+++ b/tenants/data-pipelines/data-pipelines-db.externalsecret.yaml
@@ -1,0 +1,42 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: data-pipelines-db
+  namespace: data-pipelines
+  labels:
+    zave.io/workload: data-pipelines
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: data-pipelines-db
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    - secretKey: DB_HOST
+      remoteRef:
+        key: tenants/data-pipelines/db
+        property: DB_HOST
+    - secretKey: DB_PORT
+      remoteRef:
+        key: tenants/data-pipelines/db
+        property: DB_PORT
+    - secretKey: DB_NAME
+      remoteRef:
+        key: tenants/data-pipelines/db
+        property: DB_NAME
+    - secretKey: DB_USER
+      remoteRef:
+        key: tenants/data-pipelines/db
+        property: DB_USER
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: tenants/data-pipelines/db
+        property: DB_PASSWORD
+    - secretKey: DB_SSLMODE
+      remoteRef:
+        key: tenants/data-pipelines/db
+        property: DB_SSLMODE

--- a/tenants/data-pipelines/kustomization.yaml
+++ b/tenants/data-pipelines/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - data-pipelines-db.externalsecret.yaml

--- a/tenants/data-pipelines/namespace.yaml
+++ b/tenants/data-pipelines/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: data-pipelines
+  labels:
+    zave.io/workload: data-pipelines
+    zave.io/tenant: "true"

--- a/tenants/data-pipelines/serviceaccount.yaml
+++ b/tenants/data-pipelines/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: data-pipelines
+  namespace: data-pipelines
+  annotations:
+    # IRSA annotation for EKS (AWS Secrets Manager fallback)
+    # Replace ACCOUNT_ID with actual AWS account ID when deploying to EKS
+    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/data-pipelines-secrets-reader
+  labels:
+    zave.io/workload: data-pipelines
+automountServiceAccountToken: true


### PR DESCRIPTION
  Add tenant manifests for data-pipelines workload:
  - Namespace with tenant labels
  - ServiceAccount with IRSA annotation for AWS Secrets Manager
  - ExternalSecret for DB credentials (Vault->ESO->K8s Secret)
  - Kustomization for resource bundling
  - ArgoCD Application for automated sync

  Vault path: secret/tenants/data-pipelines/db
  Target secret: data-pipelines-db (namespace: data-pipelines)

  Resolves #131

  Generated with [Claude Code](https://claude.com/claude-code)

  Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>