### PR TITLE
refactor(gitops): rename data-pipelines tenant to listings-ingest

### DIFF
--- a/docs/tenant-app-deployment-plan.md
+++ b/docs/tenant-app-deployment-plan.md
@@ -42,7 +42,7 @@ This plan does **not** define:
 | `panchito` | Flask API | PostgreSQL, Redis | External |
 | `rigoberta` | Rails web | PostgreSQL, Redis | External |
 | `thehouseguy` | Rails web | PostgreSQL, Redis, S3 | External |
-| `data-pipelines` | Airflow ETL | PostgreSQL, Airflow | Internal |
+| `listings-ingest` | Airflow ETL | PostgreSQL, Airflow | Internal |
 
 ## GitOps Decisions
 
@@ -59,7 +59,7 @@ gitops/
 │   ├── panchito/
 │   ├── rigoberta/
 │   ├── thehouseguy/
-│   └── data-pipelines/
+│   └── listings-ingest/
 └── clusters/
     └── <env>/
 ```
@@ -84,7 +84,7 @@ Recommended sequence for risk reduction:
 2. `panchito`
 3. `rigoberta`
 4. `thehouseguy`
-5. `data-pipelines`
+5. `listings-ingest`
 
 ## Phased Rollout
 
@@ -109,7 +109,7 @@ Recommended sequence for risk reduction:
 - Reconcile runtime and optional object-storage integration.
 - Verify application feature health.
 
-### Phase 6: Batch/orchestration tenant (`data-pipelines`)
+### Phase 6: Batch/orchestration tenant (`listings-ingest`)
 - Reconcile Airflow/DAG scheduling components.
 - Verify scheduled execution and data writes.
 

--- a/platform/argocd/applications/data-pipelines.yaml
+++ b/platform/argocd/applications/data-pipelines.yaml
@@ -1,20 +1,20 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: data-pipelines
+  name: listings-ingest
   namespace: argocd
   labels:
-    zave.io/workload: data-pipelines
+    zave.io/workload: listings-ingest
     zave.io/tenant: "true"
 spec:
   project: default
   source:
     repoURL: https://github.com/zavestudios/gitops
     targetRevision: main
-    path: tenants/data-pipelines
+    path: tenants/listings-ingest
   destination:
     server: https://kubernetes.default.svc
-    namespace: data-pipelines
+    namespace: listings-ingest
   syncPolicy:
     automated:
       prune: true

--- a/tenants/listings-ingest/kustomization.yaml
+++ b/tenants/listings-ingest/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - serviceaccount.yaml
-  - data-pipelines-db.externalsecret.yaml
+  - listings-ingest-db.externalsecret.yaml

--- a/tenants/listings-ingest/listings-ingest-db.externalsecret.yaml
+++ b/tenants/listings-ingest/listings-ingest-db.externalsecret.yaml
@@ -1,42 +1,42 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: data-pipelines-db
-  namespace: data-pipelines
+  name: listings-ingest-db
+  namespace: listings-ingest
   labels:
-    zave.io/workload: data-pipelines
+    zave.io/workload: listings-ingest
 spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: vault-kv
   target:
-    name: data-pipelines-db
+    name: listings-ingest-db
     creationPolicy: Owner
     template:
       type: Opaque
   data:
     - secretKey: DB_HOST
       remoteRef:
-        key: tenants/data-pipelines/db
+        key: tenants/listings-ingest/db
         property: DB_HOST
     - secretKey: DB_PORT
       remoteRef:
-        key: tenants/data-pipelines/db
+        key: tenants/listings-ingest/db
         property: DB_PORT
     - secretKey: DB_NAME
       remoteRef:
-        key: tenants/data-pipelines/db
+        key: tenants/listings-ingest/db
         property: DB_NAME
     - secretKey: DB_USER
       remoteRef:
-        key: tenants/data-pipelines/db
+        key: tenants/listings-ingest/db
         property: DB_USER
     - secretKey: DB_PASSWORD
       remoteRef:
-        key: tenants/data-pipelines/db
+        key: tenants/listings-ingest/db
         property: DB_PASSWORD
     - secretKey: DB_SSLMODE
       remoteRef:
-        key: tenants/data-pipelines/db
+        key: tenants/listings-ingest/db
         property: DB_SSLMODE

--- a/tenants/listings-ingest/namespace.yaml
+++ b/tenants/listings-ingest/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: data-pipelines
+  name: listings-ingest
   labels:
-    zave.io/workload: data-pipelines
+    zave.io/workload: listings-ingest
     zave.io/tenant: "true"

--- a/tenants/listings-ingest/serviceaccount.yaml
+++ b/tenants/listings-ingest/serviceaccount.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: data-pipelines
-  namespace: data-pipelines
+  name: listings-ingest
+  namespace: listings-ingest
   annotations:
     # IRSA annotation for EKS (AWS Secrets Manager fallback)
     # Replace ACCOUNT_ID with actual AWS account ID when deploying to EKS
-    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/data-pipelines-secrets-reader
+    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/listings-ingest-secrets-reader
   labels:
-    zave.io/workload: data-pipelines
+    zave.io/workload: listings-ingest
 automountServiceAccountToken: true


### PR DESCRIPTION
gitops:
  Rename data-pipelines tenant to listings-ingest

  Reflects specific workload purpose (listings ingestion) rather than
  generic data-pipelines naming. Prepares for future Airflow platform-service
  that will serve multiple data sources.

  Changes:
  - Renamed tenants/data-pipelines/ → tenants/listings-ingest/
  - Updated all manifest names and references
  - Updated ArgoCD Application path and namespace
  - Vault path: tenants/listings-ingest/db

  Generated with [Claude Code](https://claude.com/claude-code)

  Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>