### PR TITLE
Fix panchito VirtualService gateway reference and document exposure

### DIFF
--- a/docs/edge-exposure-plan.md
+++ b/docs/edge-exposure-plan.md
@@ -65,6 +65,7 @@ Based on current cluster observations and repo state, the relevant hosts are:
 | `vault.zavestudios.com` | Operator/admin UI | Cloudflare Access | Sensitive admin surface. |
 | `grafana-on-prem.zavestudios.com` | Operator UI | Cloudflare Access | Useful UI, but not a public app. |
 | `sso.zavestudios.com` | Keycloak IdP | Public by design | Identity plane endpoint; do not place Cloudflare Access in front of Keycloak itself. |
+| `panchito-on-prem.zavestudios.com` | Tenant workload | Public by design | Authenticated via Keycloak OIDC; no Cloudflare Access. |
 | `policyreporter.zavestudios.com` | Operator UI | Cloudflare Access | Reporting UI, not a public app. |
 | `prometheus.zavestudios.com` | Operator UI | Cloudflare Access | Observability admin surface. |
 | `alertmanager.zavestudios.com` | Operator UI | Cloudflare Access | Observability admin surface. |

--- a/tenants/panchito/virtualservice.yaml
+++ b/tenants/panchito/virtualservice.yaml
@@ -8,7 +8,7 @@ metadata:
     zave.io/workload: panchito
 spec:
   gateways:
-    - istio-gateway/public
+    - istio-gateway/public-ingressgateway
   hosts:
     - panchito-on-prem.zavestudios.com
   http:


### PR DESCRIPTION
## Summary

Fixes routing for panchito-on-prem.zavestudios.com by correcting the VirtualService gateway reference and documents the public exposure decision.

## Changes

1. **VirtualService gateway fix** (`tenants/panchito/virtualservice.yaml`)
   - Changed gateway reference from `istio-gateway/public` to `istio-gateway/public-ingressgateway`
   - This matches the actual Gateway resource name in the cluster

2. **Documentation update** (`docs/edge-exposure-plan.md`)
   - Added panchito-on-prem.zavestudios.com to the exposure matrix
   - Documented as "Public by design" with Keycloak OIDC authentication
   - No Cloudflare Access (app-level authentication)

## Problem

VirtualService was referencing non-existent gateway `istio-gateway/public`, causing 404 errors for all panchito requests even though:
- DNS resolved correctly
- Pods were running
- Service had endpoints
- ArgoCD showed healthy sync

## Validation

After merge and ArgoCD sync, verify:
```bash
curl -I https://panchito-on-prem.zavestudios.com/api/v1/health
```

Expected: HTTP 200 or redirect to Keycloak (not 404)

## Related

- Closes #138 (prerequisite for Keycloak browser validation)
- DNS record for panchito-on-prem.zavestudios.com already created in Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)