### PR TITLE
Fix panchito OIDC issuer URL path

### DIFF
--- a/tenants/panchito/deployment.yaml
+++ b/tenants/panchito/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: OIDC_ENABLED
               value: "true"
             - name: OIDC_ISSUER_URL
-              value: https://sso.zavestudios.com/realms/zavestudios
+              value: https://sso.zavestudios.com/auth/realms/zavestudios
             - name: OIDC_CLIENT_ID
               value: panchito
             - name: APP_BASE_URL


### PR DESCRIPTION
## Summary

Fixes OIDC authentication by correcting the Keycloak issuer URL to include the `/auth` path prefix.

## Problem

Panchito login was failing with:
```
404 Client Error: Not Found for url: 
https://sso.zavestudios.com/realms/zavestudios/.well-known/openid-configuration
```

Keycloak is mounted at `/auth`, not at root, based on BigBang configuration:
```yaml
- --hostname=https://sso.zavestudios.com/auth
```

## Change

Updated `OIDC_ISSUER_URL` in `tenants/panchito/deployment.yaml`:

**Before:** `https://sso.zavestudios.com/realms/zavestudios`  
**After:** `https://sso.zavestudios.com/auth/realms/zavestudios`

## Validation

Discovery endpoint now works:
```bash
curl https://sso.zavestudios.com/auth/realms/zavestudios/.well-known/openid-configuration
```

Returns valid OIDC configuration including:
- `issuer: https://sso.zavestudios.com/auth/realms/zavestudios`
- `authorization_endpoint`
- `token_endpoint`
- `userinfo_endpoint`
- `end_session_endpoint`

## Testing

After merge and ArgoCD sync, verify browser login flow:
1. Navigate to `https://panchito-on-prem.zavestudios.com/`
2. Should redirect to Keycloak login
3. After login, should redirect back to panchito with session

## Related

- Part of gitops#138 (Keycloak browser validation)
- Depends on #141 (gateway routing fix - already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)