### PR TITLE
Add tunnel ID to cloudflared run command

### DIFF
--- a/platform/cloudflare/deployment.yaml
+++ b/platform/cloudflare/deployment.yaml
@@ -40,6 +40,7 @@ spec:
         - /etc/cloudflared/creds/credentials.json
         - --no-autoupdate
         - run
+        - 24ca1f2b-5a12-497b-bdb0-49496fde9bc8
         volumeMounts:
         - name: config
           mountPath: /etc/cloudflared/config


### PR DESCRIPTION
Fix CrashLoopBackOff: "cloudflared tunnel run" requires the tunnel ID as the last argument when using credentials-file mode.

Added: 24ca1f2b-5a12-497b-bdb0-49496fde9bc8

🤖 Generated with [Claude Code](https://claude.com/claude-code)