### PR TITLE
Fix cloudflared ConfigMap ingress rules syntax

### DIFF
--- a/platform/cloudflare/configmap.yaml
+++ b/platform/cloudflare/configmap.yaml
@@ -17,3 +17,5 @@ data:
           httpHeaders:
             X-Forwarded-Proto:
               - https
+      # Required catch-all rule
+      - service: http_status:404


### PR DESCRIPTION
   Add required catch-all rule to ingress configuration. Cloudflare tunnel
   requires at least 2 ingress entries: service rules + final catch-all.

   The missing catch-all may have caused cloudflared to reject the local
   config and fall back to remote dashboard config (now empty).

   Generated with [Claude Code](https://claude.com/claude-code)

   Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>