### PR TITLE
Remove redundant catch-all from cloudflared ingress

### DIFF
--- a/platform/cloudflare/configmap.yaml
+++ b/platform/cloudflare/configmap.yaml
@@ -8,7 +8,7 @@ data:
     metrics: 0.0.0.0:2000
 
     ingress:
-      # Route all traffic to Istio public gateway
+      # Route all traffic to Istio public gateway (catch-all rule)
       - service: http://public-ingressgateway.istio-gateway.svc.cluster.local:80
         originRequest:
           noTLSVerify: true
@@ -17,5 +17,3 @@ data:
           httpHeaders:
             X-Forwarded-Proto:
               - https
-      # Required catch-all rule
-      - service: http_status:404


### PR DESCRIPTION
   The Istio gateway rule with no hostname already acts as a catch-all,
   routing all traffic to Istio. Adding a second catch-all (404) causes
   cloudflared to error: Rule