### PR TITLE
Update cloudflared to use new locally-managed tunnel

### DIFF
--- a/platform/cloudflare/deployment.yaml
+++ b/platform/cloudflare/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - /etc/cloudflared/creds/credentials.json
         - --no-autoupdate
         - run
-        - 24ca1f2b-5a12-497b-bdb0-49496fde9bc8
+        - 8e1bf1c3-1fac-4230-9b32-afb134042d49
         volumeMounts:
         - name: config
           mountPath: /etc/cloudflared/config


### PR DESCRIPTION
Replace remote-managed tunnel (24ca1f2b) with new Terraform-created locally-managed tunnel (8e1bf1c3). This tunnel is created via IaC and uses local ConfigMap for ingress configuration instead of remote dashboard config.

New tunnel created via terraform-cloudflare in kpi repo.

Generated with [Claude Code](https://claude.com/claude-code)