### PR TITLE
Add SESSION_COOKIE_DOMAIN to panchito deployment

### DIFF
--- a/tenants/panchito/deployment.yaml
+++ b/tenants/panchito/deployment.yaml
@@ -80,6 +80,8 @@ spec:
               value: https://panchito-on-prem.zavestudios.com
             - name: SESSION_COOKIE_SECURE
               value: "true"
+            - name: SESSION_COOKIE_DOMAIN
+              value: "panchito-on-prem.zavestudios.com"
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Explicitly set cookie domain to ensure Flask session cookies work correctly through OAuth redirect flow. Without this, cookies may not persist across redirect from Keycloak, causing CSRF state mismatch errors.

Generated with [Claude Code](https://claude.com/claude-code)