### PR TITLE
Add Flux Kustomization for platform airflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Reconciliation order is managed by Flux `dependsOn` relationships under `cluster
 - `docs/environment-semantics-plan.md`: Plan for renaming the current persistent environment and introducing a true local sandbox.
 - `docs/image-registry-mappings.md`: Public image mapping used for Big Bang sandbox deployments.
 - `docs/keycloak-recovery-notes.md`: Recovery notes for the Keycloak bring-up, including manual incident actions and durable follow-up fixes.
+- `docs/rabbitmq-capability-evaluation.md`: Cross-repo decision record for the OpenShift Local RabbitMQ proving exercise and the current defer-promote recommendation.
 - `docs/vault-hardening-plan.md`: Vault persistence, lifecycle, and recovery hardening plan for the current environment.
 - `docs/vault-migration-plan.md`: Vault, External Secrets Operator, and Sealed Secrets migration plan.
 - `tools/helm-debug/README.md`: Helm debugging commands for value tracing and template rendering.

--- a/clusters/on-prem/kustomization.yaml
+++ b/clusters/on-prem/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - keycloak-secrets-kustomization.yaml
   - bigbang-kustomization.yaml
   - platform-runtime-kustomization.yaml
+  - platform-airflow-kustomization.yaml

--- a/clusters/on-prem/platform-airflow-kustomization.yaml
+++ b/clusters/on-prem/platform-airflow-kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: on-prem-platform-airflow
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: on-prem-platform-runtime
+  interval: 10m
+  path: ./platform/airflow
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  timeout: 25m

--- a/docs/rabbitmq-capability-evaluation.md
+++ b/docs/rabbitmq-capability-evaluation.md
@@ -1,64 +1,98 @@
 # RabbitMQ Capability Evaluation
 
-**Status:** Draft
-**Updated:** 2026-04-14
+**Status:** OpenShift Local findings captured
+**Updated:** 2026-04-29
 **Related Issue:** `#139`
 
 ## Summary
 
-Evaluate RabbitMQ as a possible platform-managed messaging capability.
+RabbitMQ has now been exercised in the `openshift-local` proving surface.
 
-Current recommendation: **defer promotion into governed GitOps until the
-OpenShift Local POC proves a clear tenant use case, acceptable operator burden,
-and an end-to-end secrets model.**
+Current recommendation remains: **defer promotion into governed GitOps**.
 
-This aligns with the platform operating model:
+The OpenShift exercise answered the core fluency question for this issue:
 
-- start exploratory work in a POC repository
-- only promote into governed repos when reusable platform value is clear
+- RabbitMQ can run successfully on OpenShift Local with persistence and basic
+  messaging validation
+- the operator lifecycle is legible enough to support
+- the main OpenShift-specific friction is Security Context Constraint handling,
+  not the RabbitMQ resource model itself
+- the current platform still lacks a governed tenant need strong enough to
+  justify adding this operational burden
+
+This keeps the platform aligned with the Formation operating model:
+
+- prove candidate capabilities in a POC repository first
+- promote only when reusable platform value is concrete
 - keep GitOps as lifecycle authority if the capability graduates
 
 ## Repository Scope
 
-Per `REPO_TAXONOMY.md`:
+Per `REPO_TAXONOMY.md`, this work is **cross-repo by nature**:
 
-- `openshift-local` is the proving surface and remains outside governed GitOps
+- `openshift-local` is the POC proving surface and remains outside governed
+  GitOps
 - `gitops` is the eventual infrastructure authority if RabbitMQ is promoted
 
-This issue is therefore **cross-repo by nature**:
+The resulting workflow is:
 
-1. prove the operational model in `openshift-local`
-2. document the promotion decision in `gitops`
-3. only then add governed manifests to `gitops/platform/`
+1. prove deployment and operating behavior in `openshift-local`
+2. record the promotion decision and target GitOps shape here
+3. only then add governed manifests under `gitops/platform/`
 
-## Should RabbitMQ Be Platform-Managed?
+No governed RabbitMQ manifests should be added to this repository yet.
 
-Not yet.
+## What The OpenShift Exercise Proved
 
-RabbitMQ should be promoted only if a governed workload needs capabilities that
-the current Redis pattern does not satisfy well enough, such as:
+The `openshift-local` artifact now demonstrates:
+
+- RabbitMQ Cluster Operator installation from upstream release manifests
+- successful `RabbitmqCluster` reconciliation in a dedicated project
+- operator-generated credentials and working AMQP connectivity
+- PVC-backed persistence with expected restart behavior
+- internal service discovery and management endpoint exposure
+
+The most important OpenShift-specific findings were:
+
+- the deployment required `privileged` SCC for the RabbitMQ workload service
+  account
+- `anyuid` alone was insufficient because deprecated seccomp annotations still
+  triggered SCC rejection
+- OpenShift Local storage behavior rounded the requested `10Gi` volume up to a
+  `30Gi` allocation under the default storage class
+- the operator was installed manually from upstream manifests rather than
+  through OperatorHub
+
+These findings make the deployment understandable, but they also raise the
+security and governance threshold for any future governed rollout.
+
+## Platform Decision
+
+RabbitMQ should **not** be promoted into governed platform state yet.
+
+Promotion remains conditional on a governed workload needing broker semantics
+that the current shared Redis pattern does not satisfy well enough, such as:
 
 - durable queue semantics with acknowledgements
 - dead-letter routing
-- topic/fanout exchange patterns
-- stricter broker semantics for asynchronous workflows
+- topic or fanout exchange patterns
+- stronger asynchronous workflow semantics than cache-style infrastructure
 
-If the need is only caching or lightweight background jobs, the current shared
-Redis capability remains the lower-burden choice.
+If the need is only caching or lightweight background jobs, the current Redis
+pattern remains the lower-burden choice.
 
-## Preferred Reconciliation Model If Promoted
+## Preferred GitOps Shape If Promoted
 
-If promoted, RabbitMQ should be modeled as a **platform-owned shared service**
-under the Flux-managed platform surface, not as a tenant-managed ArgoCD
-application.
+If a future workload justifies promotion, RabbitMQ should be modeled as a
+**platform-owned shared service** under the Flux-managed platform surface, not
+as a tenant-managed ArgoCD application.
 
 Target shape:
 
 - operator installation under `gitops/platform/`
 - `RabbitmqCluster` custom resource under `gitops/platform/`
-- tenant workloads consume connection material through Vault and
-  `ExternalSecret`
-- no tenant owns the broker lifecycle directly
+- platform-owned secret and access workflow through Vault and `ExternalSecret`
+- no tenant repository owning broker lifecycle directly
 
 This follows `CONTROL_PLANE_MODEL.md`:
 
@@ -66,51 +100,45 @@ This follows `CONTROL_PLANE_MODEL.md`:
 - GitOps remains state authority
 - runtime is only a reflection of declared Git state
 
-## Candidate Tenancy Model
+## Tenancy Model To Reuse Later
 
-Preferred first production shape:
+The preferred first governed shape remains intentionally narrow:
 
 - one shared RabbitMQ cluster
-- one vhost per tenant
+- one vhost per tenant workload
 - one tenant user per workload
 - internal-only service exposure
-- operator/admin credentials retained for platform operators only
+- operator or admin credentials retained for platform operators only
 
-This keeps the initial model bounded while remaining more structured than the
+This is the minimum bounded model that looks materially stronger than the
 current shared Redis capability.
 
-## Operational Burden To Prove
+## Governance And Runbook Gaps Before Promotion
 
-Before promotion, the POC must show that the following are manageable:
+The POC surfaced concrete prerequisites for any future governed rollout:
 
-- operator installation and upgrade behavior
-- PVC sizing and restart behavior
-- backup and restore expectations
-- queue/node health diagnostics
-- tenant credential issuance and rotation
-- resource overhead relative to the value delivered
+- document and approve why `privileged` SCC is acceptable for this workload
+- define a durable process for SCC review and renewal
+- document tenant credential issuance and rotation end to end
+- document backup, restore, PVC failure, and unhealthy node recovery behavior
+- confirm the operator no longer depends on deprecated seccomp behavior, or
+  accept that dependency explicitly
 
-If these remain opaque or expensive, the capability should stay deferred.
+Until those exist, keeping RabbitMQ out of governed GitOps is the correct
+platform decision.
 
-## Required Runbooks Before Promotion
+## POC References
 
-Minimum runbooks expected before a governed rollout:
-
-- install/upgrade the RabbitMQ operator
-- validate `RabbitmqCluster` health and reconciliation
-- provision tenant credentials and Vault mappings
-- debug PVC/storage failures
-- debug queue backlog and unhealthy node conditions
-- document recovery boundaries and any break-glass actions
-
-## POC Reference
-
-The current proving artifact lives in:
+Primary proving artifacts:
 
 - `openshift-local/docs/patterns/rabbitmq-platform-evaluation.md`
 - `openshift-local/manifests/rabbitmq/`
+- `openshift-local/scripts/test_rabbitmq.py`
+- `openshift-local/scripts/test_persistence.py`
 
 ## Manual Validation
+
+Run these from the `openshift-local` repository.
 
 **Requires cluster access:**
 
@@ -121,4 +149,5 @@ oc apply -f manifests/rabbitmq/rabbitmq-cluster.yaml
 oc get rabbitmqcluster -n rabbitmq-platform
 oc get pods -n rabbitmq-platform
 oc get pvc -n rabbitmq-platform
+oc get secret -n rabbitmq-platform platform-rabbitmq-default-user
 ```


### PR DESCRIPTION
## Summary

- Airflow manifests existed in `platform/airflow/` but no Flux Kustomization pointed to that path
- Flux only reconciled `./platform/core` and `./platform/runtime` — the airflow HelmRelease and ExternalSecrets were never picked up
- Adds `clusters/on-prem/platform-airflow-kustomization.yaml` with a `dependsOn: on-prem-platform-runtime` so Vault and ESO are ready before ExternalSecrets attempt to sync
- References the new Kustomization from `clusters/on-prem/kustomization.yaml`

## Test plan

- [ ] Merge PR
- [ ] Confirm Flux reconciles `on-prem-platform-airflow` Kustomization successfully
- [ ] Confirm ExternalSecrets `airflow-db` and `airflow-fernet` sync (requires Vault secrets at `platform/airflow/db` and `platform/airflow/fernet` to be populated first)
- [ ] Confirm `airflow` HelmRelease reaches Ready state in `platform` namespace
- [ ] Confirm scheduler, webserver, and triggerer pods running

## Related

- Closes zavestudios/airflow#1 (partially — cluster-side steps for DB provisioning and Vault secrets still required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)