### PR TITLE
Fix airflow Vault paths and Postgres host

### DIFF
--- a/platform/airflow/airflow-db.externalsecret.yaml
+++ b/platform/airflow/airflow-db.externalsecret.yaml
@@ -16,5 +16,5 @@ spec:
   data:
     - secretKey: connection
       remoteRef:
-        key: platform/airflow/db
+        key: platform/services/airflow/db
         property: DATABASE_URL

--- a/platform/airflow/airflow-fernet.externalsecret.yaml
+++ b/platform/airflow/airflow-fernet.externalsecret.yaml
@@ -16,5 +16,5 @@ spec:
   data:
     - secretKey: fernet-key
       remoteRef:
-        key: platform/airflow/fernet
+        key: platform/services/airflow/fernet
         property: FERNET_KEY

--- a/platform/airflow/helmrelease.yaml
+++ b/platform/airflow/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
       metadataConnection:
         user: airflow_app
         protocol: postgresql
-        host: postgres.platform.svc.cluster.local
+        host: 192.168.122.20
         port: 5432
         db: db_airflow
         sslmode: disable


### PR DESCRIPTION
## Summary

- Correct ExternalSecret Vault paths from `platform/airflow/` to `platform/services/airflow/` to align with the convention used by other platform services (keycloak)
- Fix HelmRelease Postgres host: `postgres.platform.svc.cluster.local` does not exist — the shared Postgres VM is at `192.168.122.20`

## Test plan

- [ ] Merge PR and confirm Flux reconciles the updated ExternalSecrets
- [ ] Confirm `airflow-db` and `airflow-fernet` ExternalSecrets sync successfully after Vault secrets are written to `platform/services/airflow/db` and `platform/services/airflow/fernet`
- [ ] Confirm airflow HelmRelease reaches Ready state

🤖 Generated with [Claude Code](https://claude.com/claude-code)