### PR TITLE
Fix airflow HelmRelease metadataConnection schema

### DIFF
--- a/platform/airflow/helmrelease.yaml
+++ b/platform/airflow/helmrelease.yaml
@@ -39,15 +39,7 @@ spec:
       enabled: false
 
     data:
-      metadataConnection:
-        user: airflow_app
-        protocol: postgresql
-        host: 192.168.122.20
-        port: 5432
-        db: db_airflow
-        sslmode: disable
-        passwordSecret: airflow-db
-        passwordSecretKey: connection
+      metadataSecretName: airflow-db
 
     # Fernet key for encryption
     fernetKeySecretName: airflow-fernet


### PR DESCRIPTION
## Summary

- Replace invalid `metadataConnection` fields (`passwordSecret`, `passwordSecretKey`) with `metadataSecretName`
- This is the correct schema for airflow chart 1.15.0 — the chart expects a secret with a `connection` key containing the full SQLAlchemy URL
- The `airflow-db` ExternalSecret already provides this

## Test plan

- [ ] Merge PR
- [ ] Confirm HelmRelease install succeeds
- [ ] Confirm airflow scheduler, webserver, and triggerer pods reach Running state

🤖 Generated with [Claude Code](https://claude.com/claude-code)