### PR TITLE
Fix airflow security contexts for Kyverno compliance

### DIFF
--- a/platform/airflow/helmrelease.yaml
+++ b/platform/airflow/helmrelease.yaml
@@ -59,6 +59,19 @@ spec:
         ports:
           - name: http
             port: 8080
+      securityContexts:
+        container:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+      waitForMigrations:
+        securityContexts:
+          container:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
 
     # Scheduler configuration
     scheduler:
@@ -70,6 +83,19 @@ spec:
         limits:
           cpu: 500m
           memory: 512Mi
+      securityContexts:
+        container:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+      waitForMigrations:
+        securityContexts:
+          container:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
 
     # Triggerer configuration (for deferrable operators)
     triggerer:
@@ -82,6 +108,19 @@ spec:
         limits:
           cpu: 200m
           memory: 256Mi
+      securityContexts:
+        container:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+      waitForMigrations:
+        securityContexts:
+          container:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
 
     # DAG git-sync configuration
     dags:
@@ -123,7 +162,7 @@ spec:
         runAsUser: 50000
         runAsGroup: 0
         fsGroup: 0
-      container:
+      containers:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
         capabilities:


### PR DESCRIPTION
## Summary

- Set `capabilities.drop: [ALL]` explicitly on each component's (`webserver`, `scheduler`, `triggerer`) main container and `waitForMigrations` init container
- The global `securityContexts.containers` value does not propagate to per-component init containers in chart 1.15.0 — each must be set explicitly
- Fix global key from `container` (singular) to `containers` (plural) to match the chart schema
- Kyverno `require-drop-all-capabilities` was blocking install of the scheduler Deployment and triggerer StatefulSet due to init containers not declaring `capabilities.drop: ALL`

## Test plan

- [ ] Merge PR
- [ ] Confirm HelmRelease install succeeds without Kyverno admission rejections
- [ ] Confirm scheduler, webserver, and triggerer pods reach Running state

🤖 Generated with [Claude Code](https://claude.com/claude-code)