### PR TITLE
Fix git-sync container missing capabilities.drop for Kyverno

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -137,6 +137,12 @@ spec:
           limits:
             cpu: 100m
             memory: 128Mi
+        securityContexts:
+          container:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
 
     # KubernetesPodOperator configuration
     config:


### PR DESCRIPTION
## Summary

The `dags.gitSync` container has its own `securityContexts.container` path in the chart schema and does not inherit from global or per-component security context settings.

Kyverno `require-drop-all-capabilities` was blocking the scheduler Deployment and triggerer StatefulSet because the git-sync init/sidecar container lacked `capabilities.drop: [ALL]`.

## Test plan

- [ ] Merge PR
- [ ] Confirm HelmRelease install succeeds without Kyverno admission rejections
- [ ] Confirm scheduler, webserver, and triggerer pods reach Running state

🤖 Generated with [Claude Code](https://claude.com/claude-code)