### PR TITLE
Fix airflow pod security context for Kyverno require-non-root-group

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -166,8 +166,8 @@ spec:
     securityContexts:
       pod:
         runAsUser: 50000
-        runAsGroup: 0
-        fsGroup: 0
+        runAsGroup: 50000
+        fsGroup: 50000
       containers:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

`runAsGroup: 0` and `fsGroup: 0` were being rejected by Kyverno's `require-non-root-group` policy, which requires group IDs to be > 0. Set both to `50000` (the airflow user's UID) to satisfy the policy.

## Test plan

- [ ] Merge PR
- [ ] Force HelmRelease reconcile (suspend/resume or `helm uninstall airflow -n platform`)
- [ ] Confirm webserver, scheduler, and triggerer pods reach Running state

🤖 Generated with [Claude Code](https://claude.com/claude-code)