### PR TITLE
fix(airflow): add docker.io/ prefix to all image references for Kyverno

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -24,6 +24,10 @@ spec:
     remediation:
       retries: 3
   values:
+    # Explicit registry prefix required for Kyverno restrict-image-registries policy
+    defaultAirflowRepository: docker.io/apache/airflow
+    defaultAirflowTag: "2.9.3-python3.11"
+
     # Executor configuration
     executor: KubernetesExecutor
 
@@ -148,7 +152,7 @@ spec:
     config:
       kubernetes:
         namespace: platform
-        worker_container_repository: apache/airflow
+        worker_container_repository: docker.io/apache/airflow
         worker_container_tag: 2.9.3-python3.11
         delete_worker_pods: "True"
         delete_worker_pods_on_failure: "False"


### PR DESCRIPTION
## Summary

- Sets `defaultAirflowRepository: docker.io/apache/airflow` and `defaultAirflowTag: "2.9.3-python3.11"` to override the chart default `apache/airflow` (no registry prefix)
- Fixes `config.kubernetes.worker_container_repository` from `apache/airflow` to `docker.io/apache/airflow`

The Kyverno `restrict-image-registries` policy pattern-matches on the full image reference including registry prefix. Without `docker.io/`, pods are blocked with "Image registry is not in the approved list."

## Test plan

- [ ] HelmRelease reconciles successfully after merge
- [ ] Webserver, scheduler, and triggerer pods come online
- [ ] No `restrict-image-registries` events in `kubectl get events -n platform`

Closes zavestudios/gitops#164