### PR TITLE
fix(airflow): add app.kubernetes.io/name label for Kyverno require-labels

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -24,6 +24,10 @@ spec:
     remediation:
       retries: 3
   values:
+    # Required by Kyverno require-labels policy — applied to all pod templates
+    labels:
+      app.kubernetes.io/name: airflow
+
     # Explicit registry prefix required for Kyverno restrict-image-registries policy
     defaultAirflowRepository: docker.io/apache/airflow
     defaultAirflowTag: "2.9.3-python3.11"


### PR DESCRIPTION
## Summary

- Adds a top-level `labels` block with `app.kubernetes.io/name: airflow` to the HelmRelease values
- Propagates to all Airflow pod templates (webserver, scheduler, triggerer, statsd) via the chart's global labels mechanism
- Fixes Kyverno `require-labels/autogen-check-for-labels` policy violations blocking pod creation

## Test plan

- [ ] HelmRelease reconciles after merge
- [ ] No `require-labels` PolicyViolation events in `kubectl get events -n platform`
- [ ] Webserver, scheduler, and triggerer pods come online