### PR TITLE
fix(airflow): add podLabels to all pod templates for Kyverno require-labels

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -24,10 +24,6 @@ spec:
     remediation:
       retries: 3
   values:
-    # Required by Kyverno require-labels policy — applied to all pod templates
-    labels:
-      app.kubernetes.io/name: airflow
-
     # Explicit registry prefix required for Kyverno restrict-image-registries policy
     defaultAirflowRepository: docker.io/apache/airflow
     defaultAirflowTag: "2.9.3-python3.11"
@@ -54,6 +50,8 @@ spec:
 
     # Web server configuration
     webserver:
+      podLabels:
+        app.kubernetes.io/name: airflow
       replicas: 1
       resources:
         requests:
@@ -83,6 +81,8 @@ spec:
 
     # Scheduler configuration
     scheduler:
+      podLabels:
+        app.kubernetes.io/name: airflow
       replicas: 1
       resources:
         requests:
@@ -108,6 +108,8 @@ spec:
     # Triggerer configuration (for deferrable operators)
     triggerer:
       enabled: true
+      podLabels:
+        app.kubernetes.io/name: airflow
       replicas: 1
       resources:
         requests:
@@ -129,6 +131,11 @@ spec:
             capabilities:
               drop:
                 - ALL
+
+    # StatsD — metrics sidecar, also needs the label on its pod template
+    statsd:
+      podLabels:
+        app.kubernetes.io/name: airflow
 
     # DAG git-sync configuration
     dags:


### PR DESCRIPTION
## Summary

- Removes ineffective top-level `labels` block (applies to Deployment objects, not pod templates)
- Adds explicit `podLabels: app.kubernetes.io/name: airflow` to webserver, scheduler, triggerer, and statsd — the four components with pod templates
- Fixes Kyverno `require-labels/autogen-check-for-labels` violations at `/spec/template/metadata/labels`

## Test plan

- [ ] HelmRelease reconciles after merge
- [ ] No `require-labels` PolicyViolation events in `kubectl get events -n platform`
- [ ] Webserver, scheduler, and triggerer pods reach Running state