### PR TITLE
fix(airflow): add app.kubernetes.io/version to podLabels for Kyverno

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -52,6 +52,7 @@ spec:
     webserver:
       podLabels:
         app.kubernetes.io/name: airflow
+        app.kubernetes.io/version: "2.9.3"
       replicas: 1
       resources:
         requests:
@@ -83,6 +84,7 @@ spec:
     scheduler:
       podLabels:
         app.kubernetes.io/name: airflow
+        app.kubernetes.io/version: "2.9.3"
       replicas: 1
       resources:
         requests:
@@ -110,6 +112,7 @@ spec:
       enabled: true
       podLabels:
         app.kubernetes.io/name: airflow
+        app.kubernetes.io/version: "2.9.3"
       replicas: 1
       resources:
         requests:
@@ -136,6 +139,7 @@ spec:
     statsd:
       podLabels:
         app.kubernetes.io/name: airflow
+        app.kubernetes.io/version: "2.9.3"
 
     # DAG git-sync configuration
     dags:


### PR DESCRIPTION
## Summary

- Adds `app.kubernetes.io/version: "2.9.3"` to `podLabels` for webserver, scheduler, triggerer, and statsd
- Fixes `require-labels/check-for-labels` violation at `/metadata/labels/app.kubernetes.io/version/`
- The `autogen-check-for-labels` rule (pod templates) was fixed in #166; this fixes the direct Pod rule

## Test plan

- [ ] No `require-labels` PolicyViolation events after reconciliation
- [ ] Scheduler pod comes up and runs DB migrations
- [ ] `wait-for-airflow-migrations` init container completes successfully
- [ ] Webserver reaches Running state