### PR TITLE
feat(platform): inject required labels via Kyverno mutating policy

### DIFF
--- a/platform/policies/kyverno/inject-required-labels.yaml
+++ b/platform/policies/kyverno/inject-required-labels.yaml
@@ -1,0 +1,18 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: inject-required-labels
+spec:
+  rules:
+    - name: inject-name-and-version
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              +(app.kubernetes.io/name): "{{ request.object.metadata.labels.app || request.object.metadata.labels.release || 'unknown' }}"
+              +(app.kubernetes.io/version): "{{ request.object.metadata.labels.version || 'unset' }}"

--- a/platform/policies/kyverno/kustomization.yaml
+++ b/platform/policies/kyverno/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ghcr-secret.external-secret.yaml
   - require-signed-ghcr-images.yaml
+  - inject-required-labels.yaml

--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -50,9 +50,6 @@ spec:
 
     # Web server configuration
     webserver:
-      podLabels:
-        app.kubernetes.io/name: airflow
-        app.kubernetes.io/version: "2.9.3"
       replicas: 1
       resources:
         requests:
@@ -82,9 +79,6 @@ spec:
 
     # Scheduler configuration
     scheduler:
-      podLabels:
-        app.kubernetes.io/name: airflow
-        app.kubernetes.io/version: "2.9.3"
       replicas: 1
       resources:
         requests:
@@ -110,9 +104,6 @@ spec:
     # Triggerer configuration (for deferrable operators)
     triggerer:
       enabled: true
-      podLabels:
-        app.kubernetes.io/name: airflow
-        app.kubernetes.io/version: "2.9.3"
       replicas: 1
       resources:
         requests:
@@ -134,12 +125,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-
-    # StatsD — metrics sidecar, also needs the label on its pod template
-    statsd:
-      podLabels:
-        app.kubernetes.io/name: airflow
-        app.kubernetes.io/version: "2.9.3"
 
     # DAG git-sync configuration
     dags:


### PR DESCRIPTION
## Summary

- Adds `ClusterPolicy` `inject-required-labels` that mutates pods at admission to set `app.kubernetes.io/name` and `app.kubernetes.io/version` when absent
- Sources `name` from existing `app` or `release` chart labels; sources `version` from `version` label or falls back to `unset`
- Uses Kyverno `+()` syntax so existing labels are never overwritten
- Removes `podLabels` from the airflow HelmRelease — chart 1.15.0 schema rejects `podLabels` as an additional property on webserver/scheduler/triggerer/statsd
- DRY: one policy covers all current and future platform workloads; no per-chart values required

## Test plan

- [ ] `inject-required-labels` ClusterPolicy is `Ready` in cluster
- [ ] Airflow HelmRelease upgrade succeeds (no schema validation error)
- [ ] Airflow pods have `app.kubernetes.io/name` and `app.kubernetes.io/version` injected
- [ ] No `require-labels` PolicyViolation events in `kubectl get events -n platform`
- [ ] Webserver, scheduler, and triggerer pods reach Running state