### PR TITLE
fix(airflow): exempt from require-non-root-group, revert GID to 0

### DIFF
--- a/platform/services/airflow/airflow-non-root-group-exception.yaml
+++ b/platform/services/airflow/airflow-non-root-group-exception.yaml
@@ -1,0 +1,25 @@
+apiVersion: kyverno.io/v2beta1
+kind: PolicyException
+metadata:
+  name: airflow-non-root-group
+  namespace: platform
+spec:
+  exceptions:
+    - policyName: require-non-root-group
+      ruleNames:
+        - run-as-group
+        - fs-group
+        - supplemental-groups
+        - autogen-run-as-group
+        - autogen-fs-group
+        - autogen-supplemental-groups
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - platform
+          selector:
+            matchLabels:
+              release: airflow

--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -170,8 +170,8 @@ spec:
     securityContexts:
       pod:
         runAsUser: 50000
-        runAsGroup: 50000
-        fsGroup: 50000
+        runAsGroup: 0
+        fsGroup: 0
       containers:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true

--- a/platform/services/airflow/kustomization.yaml
+++ b/platform/services/airflow/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - airflow-fernet.externalsecret.yaml
   - helmrelease.yaml
   - rbac.yaml
+  - airflow-non-root-group-exception.yaml


### PR DESCRIPTION
## Summary

- Adds `PolicyException` `airflow-non-root-group` exempting airflow pods from all three rules in `require-non-root-group` (run-as-group, fs-group, supplemental-groups) and their autogen variants
- Scoped to pods in the `platform` namespace with `release: airflow` label
- Reverts `runAsGroup` and `fsGroup` from `50000` back to `0` in the HelmRelease

## Reason

The Airflow image entrypoint requires GID=0 to correctly configure the runtime environment. Setting `runAsGroup: 50000` / `fsGroup: 50000` caused the `wait-for-airflow-migrations` init container to crash immediately after the entrypoint warning, before even attempting the DB connection.

## Test plan

- [ ] `wait-for-airflow-migrations` init container completes successfully
- [ ] Scheduler runs DB migrations
- [ ] Webserver, scheduler, and triggerer pods reach Running state
- [ ] No new PolicyViolation events for airflow pods