### PR TITLE
chore(flux): remove wait=true and reduce interval on platform-services kustomization

### DIFF
--- a/clusters/on-prem/platform-services-kustomization.yaml
+++ b/clusters/on-prem/platform-services-kustomization.yaml
@@ -6,11 +6,10 @@ metadata:
 spec:
   dependsOn:
     - name: on-prem-platform-runtime
-  interval: 10m
+  interval: 2m
   path: ./platform/services
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
-  wait: true
   timeout: 25m


### PR DESCRIPTION
## Summary

- Removes `wait: true` from `on-prem-platform-services` Kustomization
- Reduces interval from `10m` to `2m`

## Rationale

`wait: true` causes the Kustomization to stall when any HelmRelease under it is unhealthy, which blocks all future git reconciliations. This is the wrong layer for health-gating — ordering between Kustomizations is handled by `dependsOn`, and ordering between HelmReleases within a Kustomization is handled by `dependsOn` on the HelmRelease spec. HelmReleases manage their own upgrade/health lifecycle and should not be able to poison the Kustomization reconciliation loop.

`wait: true` is only justified when another Kustomization has `dependsOn` on this one and genuinely needs all resources healthy before proceeding. Nothing currently `dependsOn` `on-prem-platform-services`.