### PR TITLE
fix(airflow): mount emptyDir at /opt/airflow for readOnlyRootFilesystem

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -174,6 +174,7 @@ spec:
         runAsUser: 50000
       containers:
         allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
         capabilities:
           drop:
             - ALL
@@ -182,11 +183,11 @@ spec:
     extraVolumes:
       - name: tmp
         emptyDir: {}
-      - name: logs
+      - name: airflow-home
         emptyDir: {}
 
     extraVolumeMounts:
       - name: tmp
         mountPath: /tmp
-      - name: logs
-        mountPath: /opt/airflow/logs
+      - name: airflow-home
+        mountPath: /opt/airflow


### PR DESCRIPTION
Airflow writes airflow.cfg to AIRFLOW_HOME (/opt/airflow) on startup. With readOnlyRootFilesystem: true, this fails. Mount emptyDir at /opt/airflow to provide a writable home directory while keeping the root filesystem read-only.