### PR TITLE
fix(airflow): extend webserver startup probe and increase resources

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -53,13 +53,18 @@ spec:
     # Web server configuration
     webserver:
       replicas: 1
+      startupProbe:
+        initialDelaySeconds: 30
+        failureThreshold: 24
+        periodSeconds: 10
+        timeoutSeconds: 30
       resources:
         requests:
-          cpu: 100m
-          memory: 256Mi
-        limits:
-          cpu: 500m
+          cpu: 250m
           memory: 512Mi
+        limits:
+          cpu: 1000m
+          memory: 1Gi
       service:
         type: ClusterIP
         ports:


### PR DESCRIPTION
Python import of Airflow+SQLAlchemy is CPU-bound on startup; the default 75s startup probe window is too short for this environment. Extend to 270s and raise CPU/memory to ensure the process has headroom during import.