### PR TITLE
fix(airflow): extend liveness probe timeout for scheduler and triggerer

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -87,6 +87,11 @@ spec:
     # Scheduler configuration
     scheduler:
       replicas: 1
+      livenessProbe:
+        initialDelaySeconds: 30
+        timeoutSeconds: 60
+        failureThreshold: 5
+        periodSeconds: 60
       resources:
         requests:
           cpu: 250m
@@ -112,6 +117,11 @@ spec:
     triggerer:
       enabled: true
       replicas: 1
+      livenessProbe:
+        initialDelaySeconds: 30
+        timeoutSeconds: 60
+        failureThreshold: 5
+        periodSeconds: 60
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
airflow jobs check spawns a fresh Python process on each probe invocation and imports the full Airflow module tree. On this node the import takes
>20s under CPU contention, causing repeated liveness probe timeouts and
unnecessary restarts. Raise timeoutSeconds to 60 and probe less frequently.