### PR TITLE
fix(airflow): extend startup probe timeout for scheduler and triggerer

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -86,6 +86,10 @@ spec:
     # Scheduler configuration
     scheduler:
       replicas: 1
+      startupProbe:
+        timeoutSeconds: 60
+        failureThreshold: 24
+        periodSeconds: 10
       livenessProbe:
         timeoutSeconds: 60
         failureThreshold: 5
@@ -115,6 +119,10 @@ spec:
     triggerer:
       enabled: true
       replicas: 1
+      startupProbe:
+        timeoutSeconds: 60
+        failureThreshold: 24
+        periodSeconds: 10
       livenessProbe:
         timeoutSeconds: 60
         failureThreshold: 5


### PR DESCRIPTION
airflow jobs check used for startup probes has the same cold Python import problem as the webserver. Default 20s timeout is too short; raise to 60s with 240s total window to match the webserver startup probe fix.