### PR TITLE
fix(airflow): provision stable webserver secret key for Flask sessions

### DIFF
--- a/platform/services/airflow/airflow-webserver-secret-key.externalsecret.yaml
+++ b/platform/services/airflow/airflow-webserver-secret-key.externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: airflow-webserver-secret-key
+  namespace: platform
+  labels:
+    zave.io/workload: airflow
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: airflow-webserver-secret-key
+    creationPolicy: Owner
+  data:
+    - secretKey: webserver-secret-key
+      remoteRef:
+        key: platform/services/airflow/webserver-secret-key
+        property: webserver-secret-key

--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -50,6 +50,9 @@ spec:
     # Fernet key for encryption
     fernetKeySecretName: airflow-fernet
 
+    # Webserver secret key for Flask session signing
+    webserverSecretKeySecretName: airflow-webserver-secret-key
+
     # Web server configuration
     webserver:
       replicas: 1

--- a/platform/services/airflow/kustomization.yaml
+++ b/platform/services/airflow/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - helmrepository.yaml
   - airflow-db.externalsecret.yaml
   - airflow-fernet.externalsecret.yaml
+  - airflow-webserver-secret-key.externalsecret.yaml
   - helmrelease.yaml
   - rbac.yaml


### PR DESCRIPTION
Without a stable secret key each Gunicorn worker generates its own, making session cookies invalid across workers and causing 500s on login. Store the key in Vault, expose via ExternalSecret, reference via webserverSecretKeySecretName.