### PR TITLE
feat: kyverno CI pre-validation gate for HelmRelease and tenant manifests

### DIFF
--- a/.github/workflows/kyverno-validate.yml
+++ b/.github/workflows/kyverno-validate.yml
@@ -121,9 +121,7 @@ yaml.dump(v, sys.stdout)
     name: Kyverno Validate
     needs: prepare
     if: needs.prepare.outputs.has_manifests == 'true'
-    # Pin to commit SHA after zavestudios/platform-pipelines kyverno-validate.yml is merged.
-    # Replace d685d5518ea5541950ac70b0b303b9ed1e0a9b40 with the actual merge commit SHA.
-    uses: zavestudios/platform-pipelines/.github/workflows/kyverno-validate.yml@d685d5518ea5541950ac70b0b303b9ed1e0a9b40
+    uses: zavestudios/platform-pipelines/.github/workflows/kyverno-validate.yml@2ffb9cf35a8e99b7559931b4b84ff9ccbf943790
     with:
       manifests_artifact: kyverno-manifests
       policies_artifact: kyverno-enforce-policies

--- a/.github/workflows/kyverno-validate.yml
+++ b/.github/workflows/kyverno-validate.yml
@@ -1,0 +1,129 @@
+name: Kyverno Validate
+
+on:
+  pull_request:
+    paths:
+      - 'platform/services/**/helmrelease.yaml'
+      - 'platform/policies/kyverno/enforce/**'
+      - 'tenants/**/*.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Render Manifests and Stage Policies
+    runs-on: ubuntu-latest
+    outputs:
+      has_manifests: ${{ steps.check.outputs.has_manifests }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect changed files
+        id: changed
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          base_ref="origin/${{ github.base_ref }}"
+
+          helmreleases=$(git diff --name-only "${base_ref}...HEAD" \
+            | grep -E '^platform/services/.*/helmrelease\.yaml$' || true)
+
+          tenant_manifests=$(git diff --name-only "${base_ref}...HEAD" \
+            | grep -E '^tenants/.*\.yaml$' \
+            | grep -v 'kustomization\.yaml' || true)
+
+          {
+            echo "helmreleases<<EOF"
+            echo "$helmreleases"
+            echo "EOF"
+            echo "tenant_manifests<<EOF"
+            echo "$tenant_manifests"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Render HelmRelease manifests
+        if: steps.changed.outputs.helmreleases != ''
+        run: |
+          mkdir -p rendered-manifests
+
+          while IFS= read -r hr_file; do
+            [[ -z "$hr_file" ]] && continue
+
+            release_name=$(python3 -c "import yaml,sys; d=yaml.safe_load(open('${hr_file}')); print(d['metadata']['name'])")
+            chart=$(python3 -c "import yaml,sys; d=yaml.safe_load(open('${hr_file}')); print(d['spec']['chart']['spec']['chart'])")
+            version=$(python3 -c "import yaml,sys; d=yaml.safe_load(open('${hr_file}')); print(d['spec']['chart']['spec']['version'])")
+            repo_ref=$(python3 -c "import yaml,sys; d=yaml.safe_load(open('${hr_file}')); print(d['spec']['chart']['spec']['sourceRef']['name'])")
+            service_dir=$(dirname "$hr_file")
+
+            # Find HelmRepository URL colocated with the HelmRelease
+            repo_file=$(grep -rl 'kind: HelmRepository' "$service_dir" | head -1)
+            repo_url=$(python3 -c "import yaml; d=yaml.safe_load(open('${repo_file}')); print(d['spec']['url'])")
+
+            helm repo add "$repo_ref" "$repo_url"
+            helm repo update "$repo_ref"
+
+            python3 -c "
+import yaml, json
+d = yaml.safe_load(open('${hr_file}'))
+v = d.get('spec', {}).get('values') or {}
+import sys
+yaml.dump(v, sys.stdout)
+" > /tmp/helm-values.yaml
+
+            helm template "$release_name" "${repo_ref}/${chart}" \
+              --version "$version" \
+              --values /tmp/helm-values.yaml \
+              --output-dir "rendered-manifests/${release_name}"
+          done <<< "${{ steps.changed.outputs.helmreleases }}"
+
+      - name: Stage tenant manifests
+        if: steps.changed.outputs.tenant_manifests != ''
+        run: |
+          mkdir -p rendered-manifests
+
+          while IFS= read -r manifest; do
+            [[ -z "$manifest" ]] && continue
+            dest="rendered-manifests/$(dirname "$manifest")"
+            mkdir -p "$dest"
+            cp "$manifest" "$dest/"
+          done <<< "${{ steps.changed.outputs.tenant_manifests }}"
+
+      - name: Check for staged manifests
+        id: check
+        run: |
+          if [[ -n "$(find rendered-manifests -name '*.yaml' 2>/dev/null | head -1)" ]]; then
+            echo "has_manifests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_manifests=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload manifests artifact
+        if: steps.check.outputs.has_manifests == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: kyverno-manifests
+          path: rendered-manifests/
+          retention-days: 1
+
+      - name: Upload policies artifact
+        if: steps.check.outputs.has_manifests == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: kyverno-enforce-policies
+          path: platform/policies/kyverno/enforce/
+          retention-days: 1
+
+  kyverno-validate:
+    name: Kyverno Validate
+    needs: prepare
+    if: needs.prepare.outputs.has_manifests == 'true'
+    # Pin to commit SHA after zavestudios/platform-pipelines kyverno-validate.yml is merged.
+    # Replace d685d5518ea5541950ac70b0b303b9ed1e0a9b40 with the actual merge commit SHA.
+    uses: zavestudios/platform-pipelines/.github/workflows/kyverno-validate.yml@d685d5518ea5541950ac70b0b303b9ed1e0a9b40
+    with:
+      manifests_artifact: kyverno-manifests
+      policies_artifact: kyverno-enforce-policies

--- a/platform/policies/kyverno/enforce/bigbang/add-default-capability-drop.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/add-default-capability-drop.yaml
@@ -1,0 +1,82 @@
+---
+# Source: kyverno-policies/templates/add-default-capability-drop.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-default-capability-drop
+  annotations:
+    policies.kyverno.io/title: Add Default Capability Drop
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      This policy mutates all containers in pods to drop `ALL` capabilities by default.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno 
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: add-default-capability-drop    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    mutate:
+      foreach:
+      - list: request.object.spec.containers[]
+        patchStrategicMerge:
+          spec:
+            containers:
+            - name: "{{ element.name }}"
+              securityContext:
+                capabilities:
+                  drop:
+                  - ALL
+        preconditions:
+          any:
+          - key: "{{ contains((element.securityContext.capabilities.drop[] || '[]'), 'ALL') }}"
+            operator: Equals
+            value: false
+      - list: request.object.spec.ephemeralContainers[]
+        patchStrategicMerge:
+          spec:
+            ephemeralContainers:
+            - name: "{{ element.name }}"
+              securityContext:
+                capabilities:
+                  drop:
+                  - ALL
+        preconditions:
+          any:
+          - key: "{{ contains((element.securityContext.capabilities.drop[] || '[]'), 'ALL') }}"
+            operator: Equals
+            value: false
+      - list: request.object.spec.initContainers[]
+        patchStrategicMerge:
+          spec:
+            initContainers:
+            - name: "{{ element.name }}"
+              securityContext:
+                capabilities:
+                  drop:
+                  - ALL
+        preconditions:
+          any:
+          - key: "{{ contains((element.securityContext.capabilities.drop[] || '[]'), 'ALL') }}"
+            operator: Equals
+            value: false

--- a/platform/policies/kyverno/enforce/bigbang/add-default-securitycontext.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/add-default-securitycontext.yaml
@@ -1,0 +1,51 @@
+---
+# Source: kyverno-policies/templates/add-default-securitycontext.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-default-securitycontext
+  annotations:
+    policies.kyverno.io/title: Add Default securityContext
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      A Pod securityContext entry defines fields such as the user and group which should be used to run the Pod.
+      Sometimes choosing default values for users rather than blocking is a better alternative to not impede
+      such Pod definitions. This policy will mutate a Pod to set `runAsNonRoot`, `runAsUser`, `runAsGroup`, and 
+      `fsGroup` fields within the Pod securityContext if they are not already set.     
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno 
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: add-default-securitycontext    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    mutate:
+      patchStrategicMerge:
+        spec:
+          securityContext:
+            +(runAsNonRoot): true
+            +(runAsUser): 65534
+            +(runAsGroup): 65534
+            +(fsGroup): 65534

--- a/platform/policies/kyverno/enforce/bigbang/block-ephemeral-containers.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/block-ephemeral-containers.yaml
@@ -1,0 +1,48 @@
+---
+# Source: kyverno-policies/templates/block-ephemeral-containers.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: block-ephemeral-containers
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Block Ephemeral Containers
+    policies.kyverno.io/category: Best Practices (Security)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Ephemeral containers, enabled by default in Kubernetes 1.23, allow users to use the
+      `kubectl debug` functionality and attach a temporary container to an existing Pod.
+      This may potentially be used to gain access to unauthorized information executing inside
+      one or more containers in that Pod. This policy blocks the use of ephemeral containers.  
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: block-ephemeral-containers    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "Ephemeral (debug) containers are not permitted."
+      pattern:
+        spec:
+          X(ephemeralContainers): "null"

--- a/platform/policies/kyverno/enforce/bigbang/disallow-auto-mount-service-account-token.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/disallow-auto-mount-service-account-token.yaml
@@ -1,0 +1,68 @@
+---
+# Source: kyverno-policies/templates/disallow-auto-mount-service-account-token.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-auto-mount-service-account-token
+  annotations:
+    policies.kyverno.io/title: Disallow AutoMount Service Account Tokens
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod, ServiceAccount
+    policies.kyverno.io/description: >-
+      Automouting of Kubernetes API credentials is not ideal in all circumstances. This policy finds Pods and Service Accounts
+      that automount kubernetes api credentials.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Audit
+  failurePolicy: Ignore
+  rules:
+  - name: automount-pods    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+          - StatefulSet
+          - Deployment
+    validate:
+      message: >-
+        Automount Kubernetes API Credentials is explicitly turned on. The field spec.automountServiceAccountToken 
+        must be undefined or set to false.
+      pattern:
+        spec:
+          =(automountServiceAccountToken): false
+          =(template):
+            =(spec):
+              =(automountServiceAccountToken): false
+  - name: automount-service-accounts    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - ServiceAccount
+    validate:
+      message: >-
+        Automount Kubernetes API Credentials isn't turned off. The field automountServiceAccountToken 
+        must be set to false.
+      pattern:
+        automountServiceAccountToken: false

--- a/platform/policies/kyverno/enforce/bigbang/disallow-deprecated-apis.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/disallow-deprecated-apis.yaml
@@ -1,0 +1,247 @@
+---
+# Source: kyverno-policies/templates/disallow-deprecated-apis.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-deprecated-apis
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Disallow Deprecated APIs
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/subject: Kubernetes APIs
+    policies.kyverno.io/description: >-
+      Kubernetes APIs are sometimes deprecated and removed after a few releases.
+      As a best practice, older API versions should be replaced with newer versions.
+      This policy validates for APIs that are deprecated or scheduled for removal.
+      Note that checking for some of these resources may require modifying the Kyverno
+      ConfigMap to remove filters.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Audit
+  background: true
+  failurePolicy: Ignore
+  rules:
+  - name: validate-v1-22-removals    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      any:
+      - resources:
+          kinds:
+          - admissionregistration.k8s.io/*/ValidatingWebhookConfiguration
+          - admissionregistration.k8s.io/*/MutatingWebhookConfiguration
+          - apiextensions.k8s.io/*/CustomResourceDefinition
+          - apiregistration.k8s.io/*/APIService
+          - authentication.k8s.io/*/TokenReview
+          - authorization.k8s.io/*/SubjectAccessReview
+          - authorization.k8s.io/*/LocalSubjectAccessReview
+          - authorization.k8s.io/*/SelfSubjectAccessReview
+          - certificates.k8s.io/*/CertificateSigningRequest
+          - coordination.k8s.io/*/Lease
+          - networking.k8s.io/*/Ingress
+          - networking.k8s.io/*/IngressClass
+          - rbac.authorization.k8s.io/*/ClusterRole
+          - rbac.authorization.k8s.io/*/ClusterRoleBinding
+          - rbac.authorization.k8s.io/*/Role
+          - rbac.authorization.k8s.io/*/RoleBinding
+          - scheduling.k8s.io/*/PriorityClass
+          - storage.k8s.io/*/CSIDriver
+          - storage.k8s.io/*/CSINode
+          - storage.k8s.io/*/StorageClass
+          - storage.k8s.io/*/VolumeAttachment
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: In
+        value:
+        - CREATE
+        - UPDATE
+        - BACKGROUND
+      - key: "{{request.object.apiVersion}}"
+        operator: AnyIn
+        value:
+        - admissionregistration.k8s.io/v1beta1
+        - apiextensions.k8s.io/v1beta1
+        - apiregistration.k8s.io/v1beta1
+        - authentication.k8s.io/v1beta1
+        - authorization.k8s.io/v1beta1
+        - certificates.k8s.io/v1beta1
+        - coordination.k8s.io/v1beta1
+        - extensions/v1beta1
+        - networking.k8s.io/v1beta1
+        - rbac.authorization.k8s.io/v1beta1
+        - scheduling.k8s.io/v1beta1
+        - storage.k8s.io/v1beta1
+    validate:
+      message: >-
+        {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated and will be removed in v1.22.
+        See: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+      deny: {}
+  - name: validate-v1-25-removals    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      any:
+      - resources:
+          kinds:
+          - batch/*/CronJob
+          - discovery.k8s.io/*/EndpointSlice
+          - events.k8s.io/*/Event
+          - autoscaling/*/HorizontalPodAutoscaler
+          - policy/*/PodDisruptionBudget
+          - node.k8s.io/*/RuntimeClass
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: In
+        value:
+        - CREATE
+        - UPDATE
+        - BACKGROUND
+      - key: "{{request.object.apiVersion}}"
+        operator: AnyIn
+        value:
+        - batch/v1beta1
+        - discovery.k8s.io/v1beta1
+        - events.k8s.io/v1beta1
+        - autoscaling/v2beta1
+        - policy/v1beta1
+        - node.k8s.io/v1beta1
+    validate:
+      message: >-
+        {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated and will be removed in v1.25.
+        See: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+      deny: {}
+  - name: validate-v1-26-removals    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      any:
+      - resources:
+          kinds:
+          - flowcontrol.apiserver.k8s.io/*/FlowSchema
+          - flowcontrol.apiserver.k8s.io/*/PriorityLevelConfiguration
+          - autoscaling/*/HorizontalPodAutoscaler
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: In
+        value:
+        - CREATE
+        - UPDATE
+        - BACKGROUND
+      - key: "{{request.object.apiVersion}}"
+        operator: AnyIn
+        value:
+        - flowcontrol.apiserver.k8s.io/v1beta1
+        - autoscaling/v2beta2
+    validate:
+      message: >-
+        {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated and will be removed in v1.26.
+        See: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+      deny: {}
+  - name: validate-v1-27-removals    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      any:
+      - resources:
+          kinds:
+          - storage.k8s.io/*/CSIStorageCapacity
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: In
+        value:
+        - CREATE
+        - UPDATE
+        - BACKGROUND
+      - key: "{{request.object.apiVersion}}"
+        operator: AnyIn
+        value:
+        - storage.k8s.io/v1beta1
+    validate:
+      message: >-
+        {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated and will be removed in v1.27.
+        See: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+      deny: {}
+  - name: validate-v1-29-removals    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      any:
+      - resources:
+          kinds:
+          - flowcontrol.apiserver.k8s.io/*/FlowSchema
+          - flowcontrol.apiserver.k8s.io/*/PriorityLevelConfiguration
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: In
+        value:
+        - CREATE
+        - UPDATE
+        - BACKGROUND
+      - key: "{{request.object.apiVersion}}"
+        operator: AnyIn
+        value:
+        - flowcontrol.apiserver.k8s.io/v1beta2
+    validate:
+      message: >-
+        {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated and will be removed in v1.29.
+        See: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+      deny: {}
+  - name: validate-v1-32-removals    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      any:
+      - resources:
+          kinds:
+          - flowcontrol.apiserver.k8s.io/*/FlowSchema
+          - flowcontrol.apiserver.k8s.io/*/PriorityLevelConfiguration
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: In
+        value:
+        - CREATE
+        - UPDATE
+        - BACKGROUND
+      - key: "{{request.object.apiVersion}}"
+        operator: AnyIn
+        value:
+        - flowcontrol.apiserver.k8s.io/v1beta3
+    validate:
+      message: >-
+        {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated and will be removed in v1.29.
+        See: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+      deny: {}

--- a/platform/policies/kyverno/enforce/bigbang/disallow-host-namespaces.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/disallow-host-namespaces.yaml
@@ -1,0 +1,52 @@
+---
+# Source: kyverno-policies/templates/disallow-host-namespaces.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-host-namespaces
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Disallow Host Namespaces
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Host namespaces (Process ID namespace, Inter-Process Communication namespace, and
+      network namespace) allow access to shared information and can be used to elevate
+      privileges. Pods should not be allowed access to host namespaces. This policy ensures
+      fields which make use of these host namespaces are set to `false`.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: host-namespaces    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Sharing the host namespaces is disallowed. The fields spec.hostNetwork,
+        spec.hostIPC, and spec.hostPID must not be set to true.
+      pattern:
+        spec:
+          =(hostPID): "false"
+          =(hostIPC): "false"
+          =(hostNetwork): "false"

--- a/platform/policies/kyverno/enforce/bigbang/disallow-image-tags.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/disallow-image-tags.yaml
@@ -1,0 +1,74 @@
+---
+# Source: kyverno-policies/templates/disallow-image-tags.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-image-tags
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Disallow Image Tags
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Mutable tags, like 'latest', can lead to unexpected errors if the
+      image changes. A best practice is to use an immutable tag that maps to
+      a specific version of an application Pod. This policy validates that the image
+      specifies a tag and that it is not in the list of disallowed tags.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: require-image-tag    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: In
+        value:
+        - CREATE
+        - UPDATE
+        - BACKGROUND
+    validate:
+      message: "Images without tags are mutable and not allowed."
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            pattern:
+              image: "*:*"
+  - name: validate-image-tag    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "Using a mutable image tag e.g. 'latest' is not allowed."
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            pattern:
+              image: "!*:latest"

--- a/platform/policies/kyverno/enforce/bigbang/disallow-namespaces.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/disallow-namespaces.yaml
@@ -1,0 +1,76 @@
+---
+# Source: kyverno-policies/templates/disallow-namespaces.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-namespaces
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Disallow Default Namespace
+    policies.kyverno.io/category: Best Practices (Security)
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/subject: Pod, Deployment, StatefulSet, DaemonSet, Jobs, CronJobs
+    policies.kyverno.io/description: >-
+      Kubernetes Namespaces are an optional feature that provide a way to segment and
+      isolate cluster resources across multiple applications and users. As a best
+      practice, workloads should be isolated with Namespaces. Namespaces should be required
+      and the default (empty) Namespace should not be used. This policy validates that resources
+      specify a Namespace name other than `default`.
+    # Pods will be deployed in same namespace as Pod controller if not specified in template
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: validate-namespace    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+          - Deployment
+          - StatefulSet
+          - DaemonSet
+          - Job
+          - CronJob
+    validate:
+      message: "The namespace used for this resource is not allowed."
+      pattern:
+        metadata:
+          namespace: "!default"
+  - name: require-namespace    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+          - Deployment
+          - StatefulSet
+          - DaemonSet
+          - Job
+          - CronJob
+    validate:
+      message: "A namespace is required."
+      pattern:
+        metadata:
+          namespace: "?*"

--- a/platform/policies/kyverno/enforce/bigbang/disallow-nodeport-services.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/disallow-nodeport-services.yaml
@@ -1,0 +1,49 @@
+---
+# Source: kyverno-policies/templates/disallow-nodeport-services.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-nodeport-services
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Disallow NodePort Services
+    policies.kyverno.io/category: Best Practices (Security)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
+    policies.kyverno.io/description: >-
+      A Kubernetes Service of type NodePort uses a host port to receive traffic from
+      any source. A NetworkPolicy cannot be used to control traffic to host ports.
+      Although NodePort Services can be useful, their use must be limited to Services
+      with additional upstream security checks. This policy validates that any new Services
+      do not use the `NodePort` type.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: validate-nodeport    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Service
+    validate:
+      message: "Services of type NodePort are not allowed."
+      pattern:
+        spec:
+          type: "!NodePort"

--- a/platform/policies/kyverno/enforce/bigbang/disallow-privilege-escalation.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/disallow-privilege-escalation.yaml
@@ -1,0 +1,52 @@
+---
+# Source: kyverno-policies/templates/disallow-privilege-escalation.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-privilege-escalation
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Disallow Privilege Escalation
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
+      This policy ensures the `allowPrivilegeEscalation` fields are either undefined
+      or set to `false`.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: disallow-privilege-escalation    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Privilege escalation is disallowed. The fields spec.containers[*].securityContext.allowPrivilegeEscalation,
+        spec.initContainers[*].securityContext.allowPrivilegeEscalation, and
+        spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation must be undefined or set to `false`.
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            pattern:
+              =(securityContext):
+                  =(allowPrivilegeEscalation): "false"

--- a/platform/policies/kyverno/enforce/bigbang/disallow-privileged-containers.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/disallow-privileged-containers.yaml
@@ -1,0 +1,51 @@
+---
+# Source: kyverno-policies/templates/disallow-privileged-containers.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-privileged-containers
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Disallow Privileged Containers
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Privileged mode disables most security mechanisms and must not be allowed. This policy
+      ensures Pods do not call for privileged mode.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: priviledged-containers    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Privileged mode is not allowed. The fields spec.containers[*].securityContext.privileged,
+        spec.initContainers[*].securityContext.privileged, and
+        spec.ephemeralContainers[*].securityContext.privileged must be undefined or set to false.
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            pattern:
+                =(securityContext):
+                  =(privileged): "false"

--- a/platform/policies/kyverno/enforce/bigbang/disallow-selinux-options.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/disallow-selinux-options.yaml
@@ -1,0 +1,116 @@
+---
+# Source: kyverno-policies/templates/disallow-selinux-options.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-selinux-options
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Disallow SELinux Options
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      SELinux options can be used to escalate privileges. This policy ensures that the `seLinuxOptions`
+      specified are not used.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: pod-disallow-selinux-user    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Setting SELinux user is not allowed.  The fields spec.securityContext.seLinuxOptions.user,
+        spec.containers[*].securityContext.seLinuxOptions.user, spec.initContainers[*].securityContext.seLinuxOptions.user,
+        and spec.ephemeralContainers[*].securityContext.seLinuxOptions.user must be undefined.
+      pattern:
+        spec:
+          =(securityContext):
+            =(seLinuxOptions):
+              X(user): "null"
+  - name: container-disallow-selinux-user    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Setting SELinux user is not allowed.  The fields spec.securityContext.seLinuxOptions.user,
+        spec.containers[*].securityContext.seLinuxOptions.user, spec.initContainers[*].securityContext.seLinuxOptions.user,
+        and spec.ephemeralContainers[*].securityContext.seLinuxOptions.user must be undefined.
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            pattern:
+              =(securityContext):
+                =(seLinuxOptions):
+                  X(user): "null"
+  - name: pod-disallow-selinux-role    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Setting SELinux role is not allowed.  The fields spec.securityContext.seLinuxOptions.role,
+        spec.containers[*].securityContext.seLinuxOptions.role, spec.initContainers[*].securityContext.seLinuxOptions.role,
+        and spec.ephemeralContainers[*].securityContext.seLinuxOptions.role must be undefined.
+      pattern:
+        spec:
+          =(securityContext):
+            =(seLinuxOptions):
+              X(role): "null"
+  - name: container-disallow-selinux-role    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Setting SELinux role is not allowed.  The fields spec.securityContext.seLinuxOptions.role,
+        spec.containers[*].securityContext.seLinuxOptions.role, spec.initContainers[*].securityContext.seLinuxOptions.role,
+        and spec.ephemeralContainers[*].securityContext.seLinuxOptions.role must be undefined.
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            pattern:
+              =(securityContext):
+                =(seLinuxOptions):
+                  X(role): "null"

--- a/platform/policies/kyverno/enforce/bigbang/require-drop-all-capabilities.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/require-drop-all-capabilities.yaml
@@ -1,0 +1,62 @@
+---
+# Source: kyverno-policies/templates/require-drop-all-capabilities.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-drop-all-capabilities
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Drop All Capabilities
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.5.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Capabilities permit privileged actions without giving full root access. All
+      capabilities should be dropped from a Pod, with only those required added back.
+      This policy ensures that all containers explicitly specify `drop: ["ALL"]`.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: false
+  failurePolicy: Fail
+  rules:
+  - name: drop-all-capabilities    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    preconditions:
+      all:
+      - key: "{{ request.operation || 'BACKGROUND' }}"
+        operator: NotEquals
+        value: DELETE
+    validate:
+      message: >-
+        Containers must drop all Linux capabilities by setting the fields
+        spec.containers[*].securityContext.capabilities.drop,
+        spec.initContainers[*].securityContext.capabilities.drop, and
+        spec.ephemeralContainers[*].securityContext.capabilities.drop to `ALL`.
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            deny:
+              conditions:
+                any:
+                - key: "{{ not_null(element.securityContext.capabilities.drop, '[]') | contains(@, 'ALL') }}"
+                  operator: Equals
+                  value: false

--- a/platform/policies/kyverno/enforce/bigbang/require-labels.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/require-labels.yaml
@@ -1,0 +1,51 @@
+---
+# Source: kyverno-policies/templates/require-labels.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-labels
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Require Labels
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      A common set of labels on resources allows tools to work interoperably, describing objects
+      in a common manner that all tools can understand and query.  This policy validates that
+      the labels and values specified in the required list are present on pods.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Audit
+  background: true
+  failurePolicy: Ignore
+  rules:
+  - name: check-for-labels    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        The pod is missing a required label.
+      pattern:
+        metadata:
+          labels:
+            app.kubernetes.io/name: "?*"
+            app.kubernetes.io/instance: "?*"
+            app.kubernetes.io/version: "?*"

--- a/platform/policies/kyverno/enforce/bigbang/require-non-root-group.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/require-non-root-group.yaml
@@ -1,0 +1,119 @@
+---
+# Source: kyverno-policies/templates/require-non-root-group.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-non-root-group
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Reqire Non-root Group
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Following the least privilege principle, access to the root group ID should be forbidden
+      in containers. This policy ensures containers are running with groups > 0.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: run-as-group    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        runAsGroup must be set to an id > 0 in either spec.securityContext.runAsGroup or
+        (spec.containers[*].securityContext.runAsGroup, spec.initContainers[*].securityContext.runAsGroup,
+        and spec.ephemeralContainers[*].securityContext.runAsGroup)
+      foreach:
+      - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+        preconditions:
+          all:
+    
+        pattern:
+          =(securityContext):
+            =(runAsGroup): "*"
+      - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+        preconditions:
+          any:
+          - key: "{{ request.object.spec.securityContext.runAsGroup || to_number('0') }}"
+            operator: NotEquals
+            value: 0
+          all:
+    
+        pattern:
+          =(securityContext):
+            =(runAsGroup): ">0"
+      - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+        preconditions:
+          all:
+          - key: "{{ request.object.spec.securityContext.runAsGroup || to_number('0') }}"
+            operator: Equals
+            value: 0
+    
+        anyPattern:
+        - securityContext:
+            runAsGroup: ">0"
+  - name: fs-group    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        fsGroup must be empty or set to an id > 0 in spec.securityContextChanging.
+      pattern:
+        spec:
+          =(securityContext):
+            =(fsGroup): ">0"
+  - name: supplemental-groups    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: In
+        value:
+        - CREATE
+        - UPDATE
+        - BACKGROUND
+    validate:
+      message: >-
+        Supplemental group ids must be empty or > 0 in spec.securityContext.supplementalGroups[*].
+      pattern:
+        spec:
+          =(securityContext):
+            =(supplementalGroups): ">0"

--- a/platform/policies/kyverno/enforce/bigbang/require-non-root-user.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/require-non-root-user.yaml
@@ -1,0 +1,85 @@
+---
+# Source: kyverno-policies/templates/require-non-root-user.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-non-root-user
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Reqire Non-root User
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Following the least privilege principle, containers should not be run as root. This policy ensures
+      containers either have `runAsNonRoot` set to `true` or `runAsUser` > 0.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: non-root-user    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Either `runAsNonRoot` must be set to true or `runAsUser` must be > 0 in
+        spec.securityContext or (spec.containers[*].securityContext,
+        spec.initContainers[*].securityContext, and spec.ephemeralContainers[*].securityContext)
+      foreach:
+      - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+        preconditions:
+          all:
+    
+        pattern:
+          =(securityContext):
+            =(runAsUser): "*"
+            =(runAsNonRoot): "*"
+      - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+        preconditions:
+          any:
+          - key: "{{ request.object.spec.securityContext.runAsUser || to_number('0') }}"
+            operator: NotEquals
+            value: 0
+          - key: "{{ request.object.spec.securityContext.runAsNonRoot || '0' == '1' }}" # 0 == 1 evaluates to false, avoids escaping jsmepath literal bool
+            operator: Equals
+            value: true
+          all:
+    
+        pattern:
+          =(securityContext):
+            =(runAsUser): ">0"
+            =(runAsNonRoot): "!false"
+      - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+        preconditions:
+          all:
+          - key: "{{ request.object.spec.securityContext.runAsUser || to_number('0') }}"
+            operator: Equals
+            value: 0
+          - key: "{{ request.object.spec.securityContext.runAsNonRoot || '0' == '1' }}" # 0 == 1 evaluates to false, avoids escaping jsmepath literal bool
+            operator: NotEquals
+            value: true
+    
+        anyPattern:
+        - securityContext:
+            runAsNonRoot: true
+        - securityContext:
+            runAsUser: ">0"

--- a/platform/policies/kyverno/enforce/bigbang/restrict-apparmor.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-apparmor.yaml
@@ -1,0 +1,52 @@
+---
+# Source: kyverno-policies/templates/restrict-apparmor.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-apparmor
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict AppArmor Profile
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.3.0
+    policies.kyverno.io/description: >-
+      On hosts using Debian Linux distros, AppArmor is used as an access control framework.  AppArmor uses
+      the 'runtime/default' profile by default.  This policy ensures Pods do not override the AppArmor
+      profile with values outside of the allowed list.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: app-armor    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        The AppArmor profile used is not in the approved list. The annotation
+        container.apparmor.security.beta.kubernetes.io must not be defined,
+        or must be set to a profile on the approved list.
+      pattern:
+        metadata:
+          =(annotations):
+            =(container.apparmor.security.beta.kubernetes.io/*): "runtime/default | localhost/*"

--- a/platform/policies/kyverno/enforce/bigbang/restrict-capabilities.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-capabilities.yaml
@@ -1,0 +1,59 @@
+---
+# Source: kyverno-policies/templates/restrict-capabilities.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-capabilities
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict Capabilities
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Adding capabilities is a way for containers in a Pod to request higher levels
+      of ability than those with which they may be provisioned. Many capabilities
+      allow system-level control and should be prevented. This policy checks
+      ephemeralContainers, initContainers, and containers to ensure the only
+      capabilities that are added are those in the allowed list (.values.policies.restrict-capabilities.parameters.allow).
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: capabilities    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Adding of additional capabilities beyond the allowed set is not allowed.
+        The fields spec.containers[*].securityContext.capabilities.add,
+        spec.initContainers[*].securityContext.capabilities.add, and
+        spec.ephemeralContainers[*].securityContext.capabilities.add must be in the allowed list.
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            deny:
+              conditions:
+                all:
+                - key: "{{ element.securityContext.capabilities.add[] }}"
+                  operator: AnyNotIn
+                  value:
+                  - NET_BIND_SERVICE

--- a/platform/policies/kyverno/enforce/bigbang/restrict-external-ips.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-external-ips.yaml
@@ -1,0 +1,46 @@
+---
+# Source: kyverno-policies/templates/restrict-external-ips.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-external-ips
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict External IPs (CVE-2020-8554)
+    policies.kyverno.io/category: Vulnerability
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
+    policies.kyverno.io/description: >-
+      Service externalIPs can be used for a MITM attack (CVE-2020-8554).
+      This policy restricts externalIPs to a specified list.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: external-ips    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Service
+    validate:
+      message: "Only externalIPs in the approved list are allowed."
+      pattern:
+        spec:
+          =(externalIPs): ""

--- a/platform/policies/kyverno/enforce/bigbang/restrict-external-names.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-external-names.yaml
@@ -1,0 +1,48 @@
+---
+# Source: kyverno-policies/templates/restrict-external-names.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-external-names
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict External Names (CVE-2020-8554)
+    policies.kyverno.io/category: Vulnerability
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
+    policies.kyverno.io/description: >-
+      Service external names can be used for a MITM attack (CVE-2020-8554).  External names can
+      be used by an attacker to point back to localhost or internal IP addresses for exploitation.
+      This policy restricts services using external names to a specified list.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: external-names    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Service
+    validate:
+      message: "Only external names from the approved list are allowed."
+      pattern:
+        spec:
+          (type): ExternalName
+          externalName: ""

--- a/platform/policies/kyverno/enforce/bigbang/restrict-host-path-mount-pv.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-host-path-mount-pv.yaml
@@ -1,0 +1,49 @@
+---
+# Source: kyverno-policies/templates/restrict-host-path-mount-pv.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-host-path-mount-pv
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict hostPath Volume Mountable Paths
+    policies.kyverno.io/category: Best Practices (Security)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.5.0
+    policies.kyverno.io/subject: PersistentVolume
+    policies.kyverno.io/description: >-
+      PersistentVolume using hostPath consume the underlying node's file system. If not universally disabled, 
+      they should be restricted to specific host paths to prevent access to sensitive information. 
+      This policy ensures that PV hostPath is in the allowed list.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: restrict-hostpath    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - PersistentVolume
+    validate:
+      message: PV hostPath is restricted to the allowed list.
+      pattern:
+        spec:
+          =(hostPath):
+            path: ""

--- a/platform/policies/kyverno/enforce/bigbang/restrict-host-path-mount.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-host-path-mount.yaml
@@ -1,0 +1,52 @@
+---
+# Source: kyverno-policies/templates/restrict-host-path-mount.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-host-path-mount
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict hostPath Volume Mountable Paths
+    policies.kyverno.io/category: Best Practices (Security)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.5.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      hostPath volumes consume the underlying node's file system. If hostPath volumes
+      are not universally disabled, they should be restricted to specific
+      host paths to prevent access to sensitive information. This policy ensures
+      that hostPath volume paths are in the allowed list. It is strongly
+      recommended to pair this policy with another to require readOnly on hostPath volumes.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: restrict-hostpath-dirs    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: hostPath volume paths are restricted to the allowed list.
+      pattern:
+        spec:
+          =(volumes):
+          - =(hostPath):
+              path: ""

--- a/platform/policies/kyverno/enforce/bigbang/restrict-host-path-write.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-host-path-write.yaml
@@ -1,0 +1,64 @@
+---
+# Source: kyverno-policies/templates/restrict-host-path-write.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-host-path-write
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict hostPath Volume Writable Paths
+    policies.kyverno.io/category: Best Practices (Security)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.5.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      hostPath volumes consume the underlying node's file system. If hostPath volumes
+      are not universally disabled, they should be required to be read-only.
+      Pods which are allowed to mount hostPath volumes in read/write mode pose a security risk
+      even if confined to a "safe" file system on the host and may escape those confines (see
+      https://blog.aquasec.com/kubernetes-security-pod-escape-log-mounts). This policy
+      checks containers for hostPath volumes and validates they are explicitly mounted
+      in readOnly mode.  It is strongly recommended to pair this policy with another
+      to restrict the path of hostPath volumes to a known list.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: require-readonly-hostpath    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: hostPath volumes must be mounted as readOnly.
+      foreach:
+      # Fetch all volumes in the Pod which are a hostPath. Store the names in an array. There could be multiple in a Pod so can't assume just one.
+      - list: "request.object.spec.volumes[?hostPath][]"
+        deny:
+          conditions:
+            all:
+            # For every name found for a hostPath volume (stored as `{{element}}`), check all containers, initContainers, and ephemeralContainers which mount this volume and
+            # total up the number of them. Compare that to the ones with that same name which explicitly specify that `readOnly: true`. If these two
+            # counts aren't equal, deny the Pod because at least one is attempting to mount that hostPath in read/write mode. Note that the absence of
+            # the `readOnly: true` field implies read/write access. Therefore, every hostPath volume must explicitly specify that it should be mounted
+            # in readOnly mode, regardless of where that occurs in a Pod.
+            - key: "{{ request.object.spec.[containers, initContainers, ephemeralContainers][].volumeMounts[?name == '{{element.name}}'][] | length(@) }}"
+              operator: NotEquals
+              value: "{{ request.object.spec.[containers, initContainers, ephemeralContainers][].volumeMounts[?name == '{{element.name}}' && readOnly] [] | length(@) }}"

--- a/platform/policies/kyverno/enforce/bigbang/restrict-host-ports.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-host-ports.yaml
@@ -1,0 +1,52 @@
+---
+# Source: kyverno-policies/templates/restrict-host-ports.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-host-ports
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict Host Ports
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Access to host ports allows potential snooping of network traffic and should not be
+      allowed, or at minimum restricted to a known list. This policy ensures only approved ports
+      are defined in container's `hostPort` field.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: host-ports    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        The host port used is not allowed. The fields spec.containers[*].ports[*].hostPort,
+        spec.initContainers[*].ports[*].hostPort, and spec.ephemeralContainers[*].ports[*].hostPort
+        must only include ports from the allowed list.
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            pattern:
+              =(ports):
+                - =(hostPort): ""

--- a/platform/policies/kyverno/enforce/bigbang/restrict-image-registries.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-image-registries.yaml
@@ -1,0 +1,50 @@
+---
+# Source: kyverno-policies/templates/restrict-image-registries.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-image-registries
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict Image Registries
+    policies.kyverno.io/category: Best Practices (Security)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/minversion: 1.3.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Images from unknown, public registries can be of dubious quality and may not be
+      scanned and secured, representing a high degree of risk. Requiring use of known, approved
+      registries helps reduce threat exposure by ensuring image pulls only come from them. This
+      policy validates that all images originate from a registry in the approved list.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: validate-registries    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "Image registry is not in the approved list"
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            pattern:
+              image: "registry1.dso.mil/* | ghcr.io/* | quay.io/* | docker.io/* | index.docker.io/* | registry.k8s.io/* | public.ecr.aws/*"

--- a/platform/policies/kyverno/enforce/bigbang/restrict-proc-mount.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-proc-mount.yaml
@@ -1,0 +1,54 @@
+---
+# Source: kyverno-policies/templates/restrict-proc-mount.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-proc-mount
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict Proc Mount
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The default /proc masks are set up to reduce the attack surface. This policy
+      ensures nothing but the specified procMount can be used.  By default only "Default"
+      is allowed.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: check-proc-mount    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Changing the proc mount from the default is not allowed. The fields
+        spec.containers[*].securityContext.procMount,
+        spec.initContainers[*].securityContext.procMount, and
+        spec.ephemeralContainers[*].securityContext.procMount must not be changed
+        from `Default`.
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            pattern:
+              =(securityContext):
+                  =(procMount): "Default"

--- a/platform/policies/kyverno/enforce/bigbang/restrict-seccomp.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-seccomp.yaml
@@ -1,0 +1,81 @@
+---
+# Source: kyverno-policies/templates/restrict-seccomp.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-seccomp
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict Seccomp
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The SecComp profile should not be explicitly set to Unconfined. This policy,
+      requiring Kubernetes v1.19 or later, ensures that the `seccompProfile.Type` is undefined
+      or restricted to the values in the allowed list.  By default, this is `RuntimeDefault` or
+      `Localhost`.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: pod-restrict-seccomp    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        The seccomp profile used is not in the allowed list.  The fields
+        spec.securityContext.seccompProfile.type,
+        spec.containers[*].securityContext.seccompProfile.type,
+        spec.initContainers[*].securityContext.seccompProfile.type, and
+        spec.ephemeralContainers[*].securityContext.seccompProfile.type
+        must not be set to a value outside of the approved list.
+      pattern:
+       spec:
+        =(securityContext):
+          =(seccompProfile):
+            type: "RuntimeDefault | Localhost"
+  - name: container-restrict-seccomp    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        The seccomp profile used is not in the allowed list.  The fields
+        spec.securityContext.seccompProfile.type,
+        spec.containers[*].securityContext.seccompProfile.type,
+        spec.initContainers[*].securityContext.seccompProfile.type, and
+        spec.ephemeralContainers[*].securityContext.seccompProfile.type
+        must not be set to a value outside of the approved list.
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            pattern:
+              =(securityContext):
+                =(seccompProfile):
+                  type: "RuntimeDefault | Localhost"

--- a/platform/policies/kyverno/enforce/bigbang/restrict-selinux-type.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-selinux-type.yaml
@@ -1,0 +1,73 @@
+---
+# Source: kyverno-policies/templates/restrict-selinux-type.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-selinux-type
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict SELinux Type
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      SELinux options can be used to escalate privileges. This policy ensures that the `seLinuxOptions`
+      type field is undefined or restricted to the allowed list.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: pod-selinux-options-type    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Setting SELinux type is restricted.  The values from spec.securityContext.seLinuxOptions.type,
+        spec.containers[*].securityContext.seLinuxOptions.type, spec.initContainers[*].securityContext.seLinuxOptions.type,
+        and spec.ephemeralContainers[*].securityContext.seLinuxOptions.type must be in the allowed list.
+      pattern:
+        spec:
+          =(securityContext):
+            =(seLinuxOptions):
+              =(type): "container_t | container_init_t | container_kvm_t"
+  - name: container-selinux-options-type    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Setting SELinux type is restricted.  The values from spec.securityContext.seLinuxOptions.type,
+        spec.containers[*].securityContext.seLinuxOptions.type, spec.initContainers[*].securityContext.seLinuxOptions.type,
+        and spec.ephemeralContainers[*].securityContext.seLinuxOptions.type must be in the allowed list.
+      foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            pattern:
+              =(securityContext):
+                =(seLinuxOptions):
+                  =(type): "container_t | container_init_t | container_kvm_t"

--- a/platform/policies/kyverno/enforce/bigbang/restrict-sysctl.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-sysctl.yaml
@@ -1,0 +1,54 @@
+---
+# Source: kyverno-policies/templates/restrict-sysctl.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-sysctls
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict Sysctls
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Sysctl can disable security mechanisms or affect all containers on a
+      host, and should be restricted to an allowed "safe" subset. A
+      sysctl is considered safe if it is namespaced and is isolated from other
+      Pods and processes on the same Node.  This policy ensures that all sysctls are
+      in the allowed list.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: sysctls    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        Sysctl set that is not in the allowed list.  The field spec.securityContext.sysctls
+        must only use values from the allowed list
+      pattern:
+        spec:
+          =(securityContext):
+            =(sysctls):
+              - name: "kernel.shm_rmid_forced | net.ipv4.ip_local_port_range | net.ipv4.ip_unprivileged_port_start | net.ipv4.tcp_syncookies | net.ipv4.ping_group_range | net.ipv4.ip_local_reserved_ports | net.ipv4.tcp_keepalive_time | net.ipv4.tcp_fin_timeout | net.ipv4.tcp_keepalive_intvl | net.ipv4.tcp_keepalive_probes"
+                value: "?*"

--- a/platform/policies/kyverno/enforce/bigbang/restrict-volume-types.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-volume-types.yaml
@@ -1,0 +1,68 @@
+---
+# Source: kyverno-policies/templates/restrict-volume-types.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-volume-types
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: Deployment,ReplicaSet,DaemonSet,StatefulSet
+    policies.kyverno.io/title: Restrict Volume Types
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Volume types, beyond the core set, should be restricted to limit exposure to potential vulnerabilities
+      in Container Storage Interface (CSI) drivers.  In addition, HostPath volumes should not be allowed because
+      host directories could be exploited to access shared data or escalate privileges.  This policy restricts
+      use of volume types to the allowed list.
+  labels:
+    app.kubernetes.io/name: kyverno-policies
+    helm.sh/chart: kyverno-policies-3.3.4-bb.24
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kyverno-policies
+    app.kubernetes.io/version: "3.3.4-bb.24"
+    app.kubernetes.io/component: policy
+    app.kubernetes.io/part-of: kyverno
+    app: kyverno
+spec:  
+  webhookTimeoutSeconds: 30
+  validationFailureAction: Enforce 
+  background: true
+  failurePolicy: Fail
+  rules:
+  - name: restrict-volume-types    
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+    match:
+      all:
+      - resources:
+          kinds:
+          - Pod
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: In
+        value:
+        - CREATE
+        - UPDATE
+        - BACKGROUND
+      - key: "{{ not_null(request.object.spec.volumes[], '') | length(@) }}"
+        operator: GreaterThanOrEquals
+        value: 1
+    validate:
+      message: >-
+        One or more volume types used in the pod is not in the allowed list.
+      foreach:
+      - list: "request.object.spec.volumes"
+        anyPattern:
+        - configMap: "*"
+        - csi: "*"
+        - downwardAPI: "*"
+        - emptyDir: "*"
+        - ephemeral: "*"
+        - persistentVolumeClaim: "*"
+        - projected: "*"
+        - secret: "*"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/kyverno-validate.yml` triggered on PRs that change HelmRelease or tenant manifest files
- On trigger: renders changed HelmReleases via `helm template` (using the colocated HelmRepository URL and inline spec.values), copies changed tenant YAMLs, uploads both as artifacts
- Calls the `kyverno-validate` reusable workflow in `platform-pipelines` to run `kyverno apply` against the versioned policy snapshot
- Vendors BigBang 3.17.0 `kyverno-policies 3.3.4-bb.19` as rendered ClusterPolicy YAML in `platform/policies/kyverno/enforce/bigbang/`, rendered from the DoD Platform One GitHub mirror with the registry allowlist from `bigbang/values.yaml` applied
- Adds `platform/policies/kyverno/enforce/platform/` for platform-authored Enforce-mode policies (currently empty, grows as policies promote from Audit)

## Policy snapshot

30 ClusterPolicies vendored from BigBang kyverno-policies (main branch, approximate to 3.3.4-bb.19):
- 27 Enforce-mode policies (capabilities, registry, seccomp, host-path, etc.)
- 3 Audit-mode policies (deprecated APIs, auto-mount SA token, labels)

Registry allowlist applied from `bigbang/values.yaml`: `registry1.dso.mil`, `ghcr.io`, `quay.io`, `docker.io`, `index.docker.io`, `registry.k8s.io`, `public.ecr.aws`

## Merge sequence

**Blocked on zavestudios/platform-pipelines#61** — that PR must merge first. After merge, update the reusable workflow ref on line 126 from the branch HEAD SHA to the actual merge commit SHA.

## Maintenance

When BigBang version bumps, re-render `enforce/bigbang/` as part of the same PR:
```bash
git clone --depth 1 https://github.com/DoD-Platform-One/kyverno-policies /tmp/kyverno-policies-src
helm template kyverno-policies /tmp/kyverno-policies-src/chart \
  -f /path/to/kyverno-policies-overrides.yaml \
  --output-dir /tmp/rendered
cp /tmp/rendered/kyverno-policies/templates/*.yaml platform/policies/kyverno/enforce/bigbang/
```

## Test plan

- [ ] PR CI passes (no HelmRelease or tenant manifest changes in this PR, so validate job should be skipped)
- [ ] Confirm: create a follow-on test PR that modifies `platform/services/airflow/helmrelease.yaml` and verify the kyverno-validate job triggers and passes
- [ ] Confirm: a test PR with a manifest missing `capabilities.drop: [ALL]` fails validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)