### PR TITLE
feat(airflow): expose Airflow UI via Istio VirtualService for Cloudflare Tunnel

### DIFF
--- a/platform/services/airflow/kustomization.yaml
+++ b/platform/services/airflow/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - airflow-webserver-secret-key.externalsecret.yaml
   - helmrelease.yaml
   - rbac.yaml
+  - virtualservice.yaml

--- a/platform/services/airflow/virtualservice.yaml
+++ b/platform/services/airflow/virtualservice.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: airflow
+  namespace: platform
+spec:
+  hosts:
+    - airflow-on-prem.zavestudios.com
+  gateways:
+    - istio-gateway/public
+  http:
+    - route:
+        - destination:
+            host: airflow-webserver.platform.svc.cluster.local
+            port:
+              number: 8080


### PR DESCRIPTION
## Summary

- Adds `platform/services/airflow/virtualservice.yaml` — Istio VirtualService routing `airflow-on-prem.zavestudios.com` through the `istio-gateway/public` gateway to `airflow-webserver.platform.svc.cluster.local:8080`
- Registers the VirtualService in `kustomization.yaml`

## How it works

The existing Cloudflare Tunnel catch-all routes all traffic to the Istio public ingress gateway. This VirtualService handles the `Host: airflow-on-prem.zavestudios.com` header and forwards to the Airflow webserver. TLS is terminated at Cloudflare; the tunnel-to-gateway leg is plain HTTP.

## Companion PR

DNS record, Cloudflare Access Application, and Access Policy are in `zavestudios/kubernetes-platform-infrastructure` feat/airflow-cloudflare-tunnel. Both PRs should merge together — neither is fully operational without the other.

## Test plan

- [ ] `kubectl get virtualservice airflow -n platform` shows the resource after merge
- [ ] `https://airflow-on-prem.zavestudios.com` prompts Cloudflare Access login, then loads the Airflow UI
- [ ] Unauthenticated access is blocked by Cloudflare Access

Closes zavestudios/airflow#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)