### PR TITLE
fix(airflow): correct Istio gateway ref to public-ingressgateway

### DIFF
--- a/platform/services/airflow/virtualservice.yaml
+++ b/platform/services/airflow/virtualservice.yaml
@@ -7,7 +7,7 @@ spec:
   hosts:
     - airflow-on-prem.zavestudios.com
   gateways:
-    - istio-gateway/public
+    - istio-gateway/public-ingressgateway
   http:
     - route:
         - destination:


### PR DESCRIPTION
## Summary

Corrects the gateway reference in the Airflow VirtualService from `istio-gateway/public` to `istio-gateway/public-ingressgateway`, matching the actual Gateway resource name deployed by BigBang.

The wrong name caused Istio to silently ignore the VirtualService, resulting in a 404 after Cloudflare Access authentication succeeded.

## Root cause

BigBang's istio-gateway package names the Gateway resource `public-ingressgateway`, not `public`. Confirmed via `kubectl get gw -A`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)