### PR TITLE
fix(airflow): fix triggerer log-groomer crash and rotate admin password

### DIFF
--- a/platform/services/airflow/airflow-admin-password-job.yaml
+++ b/platform/services/airflow/airflow-admin-password-job.yaml
@@ -21,12 +21,12 @@ spec:
             - /bin/bash
             - -c
             - |
-              airflow users delete --username admin --yes 2>/dev/null || true
+              airflow users delete --username "${ADMIN_USERNAME}" --yes 2>/dev/null || true
               airflow users create \
-                --username admin \
-                --password "${AIRFLOW_ADMIN_PASSWORD}" \
+                --username "${ADMIN_USERNAME}" \
+                --password "${ADMIN_PASSWORD}" \
                 --role Admin \
-                --email "${AIRFLOW_ADMIN_EMAIL}" \
+                --email "admin@zavestudios.com" \
                 --firstname Admin \
                 --lastname User
           env:
@@ -45,16 +45,16 @@ spec:
                 secretKeyRef:
                   name: airflow-webserver-secret-key
                   key: webserver-secret-key
-            - name: AIRFLOW_ADMIN_PASSWORD
+            - name: ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: airflow-admin
                   key: password
-            - name: AIRFLOW_ADMIN_EMAIL
+            - name: ADMIN_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: airflow-admin
-                  key: email
+                  key: username
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/platform/services/airflow/airflow-admin-password-job.yaml
+++ b/platform/services/airflow/airflow-admin-password-job.yaml
@@ -1,0 +1,73 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: airflow-admin-password-set
+  namespace: platform
+  labels:
+    zave.io/workload: airflow
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: airflow
+      securityContext:
+        runAsUser: 50000
+        runAsNonRoot: true
+      containers:
+        - name: set-password
+          image: docker.io/apache/airflow:2.9.3-python3.11
+          command:
+            - /bin/bash
+            - -c
+            - |
+              airflow users delete --username admin --yes 2>/dev/null || true
+              airflow users create \
+                --username admin \
+                --password "${AIRFLOW_ADMIN_PASSWORD}" \
+                --role Admin \
+                --email "${AIRFLOW_ADMIN_EMAIL}" \
+                --firstname Admin \
+                --lastname User
+          env:
+            - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-db
+                  key: connection
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet
+                  key: fernet-key
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
+            - name: AIRFLOW_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-admin
+                  key: password
+            - name: AIRFLOW_ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-admin
+                  key: email
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: airflow-home
+              mountPath: /opt/airflow
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: airflow-home
+          emptyDir: {}

--- a/platform/services/airflow/airflow-admin.externalsecret.yaml
+++ b/platform/services/airflow/airflow-admin.externalsecret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: airflow-admin
+  namespace: platform
+  labels:
+    zave.io/workload: airflow
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: airflow-admin
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: platform/services/airflow/admin
+        property: password
+    - secretKey: email
+      remoteRef:
+        key: platform/services/airflow/admin
+        property: email

--- a/platform/services/airflow/airflow-admin.externalsecret.yaml
+++ b/platform/services/airflow/airflow-admin.externalsecret.yaml
@@ -17,8 +17,8 @@ spec:
     - secretKey: password
       remoteRef:
         key: platform/services/airflow/admin
-        property: password
-    - secretKey: email
+        property: ADMIN_PASSWORD
+    - secretKey: username
       remoteRef:
         key: platform/services/airflow/admin
-        property: email
+        property: ADMIN_USERNAME

--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -150,6 +150,22 @@ spec:
             capabilities:
               drop:
                 - ALL
+      # logGroomerSidecar does not inherit global extraVolumeMounts; mount explicitly
+      # readOnlyRootFilesystem must be false here because the sidecar runs `airflow`
+      # which writes airflow.cfg to AIRFLOW_HOME (/opt/airflow) on startup
+      logGroomerSidecar:
+        extraVolumeMounts:
+          - name: tmp
+            mountPath: /tmp
+          - name: airflow-home
+            mountPath: /opt/airflow
+        securityContexts:
+          container:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: false
 
     # DAG git-sync configuration
     dags:

--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -117,6 +117,19 @@ spec:
             capabilities:
               drop:
                 - ALL
+      logGroomerSidecar:
+        extraVolumeMounts:
+          - name: tmp
+            mountPath: /tmp
+          - name: airflow-home
+            mountPath: /opt/airflow
+        securityContexts:
+          container:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: false
 
     # Triggerer configuration (for deferrable operators)
     triggerer:

--- a/platform/services/airflow/kustomization.yaml
+++ b/platform/services/airflow/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - airflow-db.externalsecret.yaml
   - airflow-fernet.externalsecret.yaml
   - airflow-webserver-secret-key.externalsecret.yaml
+  - airflow-admin.externalsecret.yaml
   - helmrelease.yaml
   - rbac.yaml
   - virtualservice.yaml
+  - airflow-admin-password-job.yaml


### PR DESCRIPTION
## Summary

- **Triggerer crash fix**: The `triggerer-log-groomer` sidecar does not inherit global `extraVolumeMounts` in the apache-airflow Helm chart. With `readOnlyRootFilesystem: true` applied from the global security context, the sidecar failed with `OSError: [Errno 30] Read-only file system: '/opt/airflow/airflow.cfg'` on every startup. Added explicit `extraVolumeMounts` (tmp, airflow-home) and set `readOnlyRootFilesystem: false` on the sidecar's security context.
- **Admin password rotation**: Adds a Vault-backed ExternalSecret (`platform/services/airflow/admin`) and a one-shot Kubernetes Job that replaces the default `admin/admin` credentials on first deployment.

## Files changed

| File | Change |
|------|--------|
| `helmrelease.yaml` | Add `triggerer.logGroomerSidecar` with explicit volume mounts and security context |
| `airflow-admin.externalsecret.yaml` | New — syncs `password` and `email` from Vault |
| `airflow-admin-password-job.yaml` | New — Job: delete + create admin user using secret-sourced password |
| `kustomization.yaml` | Add both new resources |

## Pre-merge manual step

Before merging, create the Vault secret at `platform/services/airflow/admin` with fields `password` and `email`:

```
vault kv put platform/services/airflow/admin \
  password=<new-secure-password> \
  email=admin@zavestudios.com
```

The Job will run once Flux reconciles. It is idempotent (delete-then-create).

## Test plan

- [ ] Vault secret created at `platform/services/airflow/admin`
- [ ] PR CI passes (Kyverno validate)
- [ ] After merge and Flux reconcile: `triggerer-log-groomer` no longer crashes
- [ ] Job `airflow-admin-password-set` completes successfully
- [ ] Login at airflow-on-prem.zavestudios.com with new credentials works