### PR TITLE
fix(airflow): remove serviceAccountName from admin password Job

### DIFF
--- a/platform/services/airflow/airflow-admin-password-job.yaml
+++ b/platform/services/airflow/airflow-admin-password-job.yaml
@@ -10,7 +10,6 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: airflow
       securityContext:
         runAsUser: 50000
         runAsNonRoot: true


### PR DESCRIPTION
The Job only needs DB access via env vars; it has no Kubernetes API calls. Using the airflow SA caused FailedCreate because the SA is provisioned by the HelmRelease and may not exist when the Job first reconciles.