### PR TITLE
fix(airflow): remove readOnlyRootFilesystem from global security context

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -192,12 +192,15 @@ spec:
       name: airflow
 
     # Security contexts
+    # readOnlyRootFilesystem is omitted: the chart does not propagate global
+    # extraVolumeMounts to Jobs and sidecars consistently, so every airflow
+    # component hits EROFS when initialising logging or airflow.cfg.
+    # Re-evaluate with per-component volume mounts in a hardening pass.
     securityContexts:
       pod:
         runAsUser: 50000
       containers:
         allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
         capabilities:
           drop:
             - ALL


### PR DESCRIPTION
The chart does not consistently propagate global extraVolumeMounts to Jobs (migrateDatabaseJob, createUserJob) and sidecars, so every airflow component that initialises logging or airflow.cfg hits EROFS. Non-root user (50000), drop ALL capabilities, and no privilege escalation remain in place. Revisit with per-component mounts in a hardening pass.