### PR TITLE
feat(tenants): wire listings-ingest into tenant kustomization

### DIFF
--- a/tenants/kustomization.yaml
+++ b/tenants/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - listings-ingest
   - mia
   - oracle
   - panchito


### PR DESCRIPTION
## Summary

- Adds `listings-ingest` to `tenants/kustomization.yaml` so FluxCD reconciles the namespace, ServiceAccount, and ExternalSecret manifests that already exist under `tenants/listings-ingest/`
- Without this line, none of the tenant manifests were being applied to the cluster

Closes #188 (item 1 of 5)

## Test plan

- [ ] FluxCD reconciles `listings-ingest` namespace created in cluster
- [ ] `listings-ingest` ServiceAccount appears in `listings-ingest` namespace
- [ ] `listings-ingest-db` ExternalSecret is present (will not resolve until Vault secret exists)