### PR TITLE
feat(airflow): set ETL_IMAGE and AIRFLOW_RUN_NAMESPACE for KubernetesPodOperator

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -39,6 +39,10 @@ spec:
         value: "False"
       - name: AIRFLOW__WEBSERVER__EXPOSE_CONFIG
         value: "True"
+      - name: AIRFLOW_RUN_NAMESPACE
+        value: "listings-ingest"
+      - name: ETL_IMAGE
+        value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:881cd83b940f30a6e63b9ad8e86ba7e53a103fcd7814c21c07e50c8e1ae4ab43"
 
     # External PostgreSQL configuration
     postgresql:

--- a/tenants/kustomization.yaml
+++ b/tenants/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - listings-ingest
   - mia
   - oracle
   - panchito


### PR DESCRIPTION
## Summary

- Sets `AIRFLOW_RUN_NAMESPACE=listings-ingest` so KubernetesPodOperator launches pods in the correct tenant namespace
- Sets `ETL_IMAGE` to the pinned etl-runner digest built from zavestudios/listings-ingest#25

## Related

- Closes #188 (item 3 of 5 — HelmRelease env vars)
- Depends on #191 (listings-ingest tenant wired into kustomization)
- Image automation follow-up tracked in #192

## Test plan

- [ ] FluxCD reconciles HelmRelease without error
- [ ] Airflow pods restart with new env vars present
- [ ] `hello_k8s` DAG triggered manually — pod appears in `listings-ingest` namespace and completes successfully