### PR TITLE
fix(flux): wire tenants into FluxCD reconciliation loop

### DIFF
--- a/clusters/on-prem/kustomization.yaml
+++ b/clusters/on-prem/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - bigbang-kustomization.yaml
   - platform-runtime-kustomization.yaml
   - platform-services-kustomization.yaml
+  - tenants-kustomization.yaml

--- a/clusters/on-prem/tenants-kustomization.yaml
+++ b/clusters/on-prem/tenants-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: on-prem-tenants
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: on-prem-platform-runtime
+  interval: 2m
+  path: ./tenants
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 10m


### PR DESCRIPTION
## Problem

The `tenants/` directory and its Kustomize structure existed, but there was no FluxCD `Kustomization` resource in `clusters/on-prem/` pointing at it. FluxCD only reconciles paths it is explicitly told to watch via a `Kustomization` resource. Without this, the `listings-ingest` namespace, ServiceAccount, and ExternalSecret were never applied to the cluster — discovered when the `hello_k8s` smoke test failed because `listings-ingest` namespace did not exist.

The same gap affects all other tenants (mia, oracle, panchito, rigoberta) — none of their manifests have been reconciled by FluxCD either.

## Changes

- `clusters/on-prem/tenants-kustomization.yaml` — new FluxCD Kustomization watching `./tenants`, depending on `on-prem-platform-runtime`
- `clusters/on-prem/kustomization.yaml` — adds the new resource

## Test plan

**Requires cluster access:**
- [ ] `kubectl get kustomization -n flux-system on-prem-tenants` shows Ready
- [ ] `kubectl get namespace listings-ingest` exists after reconciliation
- [ ] `kubectl get serviceaccount -n listings-ingest listings-ingest` exists