### PR TITLE
feat(argocd): add listings-ingest Application

### DIFF
--- a/platform/argocd/applications/kustomization.yaml
+++ b/platform/argocd/applications/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - listings-ingest.yaml
   - mia.yaml
   - oracle.yaml
   - panchito.yaml

--- a/platform/argocd/applications/listings-ingest.yaml
+++ b/platform/argocd/applications/listings-ingest.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: listings-ingest
+  namespace: argocd
+  labels:
+    zave.io/workload: listings-ingest
+    zave.io/tenant: "true"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/zavestudios/gitops
+    targetRevision: main
+    path: tenants/listings-ingest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: listings-ingest
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/tenants/kustomization.yaml
+++ b/tenants/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - listings-ingest
   - mia
   - oracle
   - panchito


### PR DESCRIPTION
## Summary

Adds an ArgoCD Application for `listings-ingest`, consistent with how `mia`, `oracle`, `panchito`, and `rigoberta` are managed. Replaces the closed FluxCD-based approach (#195).

ArgoCD will:
- Create the `listings-ingest` namespace (via `CreateNamespace=true`)
- Reconcile the ServiceAccount and ExternalSecret manifests from `tenants/listings-ingest/`
- Prune and self-heal as with other tenants

Closes #188 (item 1 — namespace and tenant wiring)

## Test plan

**Requires cluster access:**
- [ ] ArgoCD Application `listings-ingest` shows Synced and Healthy
- [ ] `kubectl get namespace listings-ingest` exists
- [ ] `kubectl get serviceaccount -n listings-ingest listings-ingest` exists
- [ ] Re-trigger `hello_k8s` DAG and verify pod runs in `listings-ingest` namespace