### PR TITLE
fix(namespaces): patch default SA in listings-ingest and mia namespaces

### DIFF
--- a/platform/namespaces/default-serviceaccounts.yaml
+++ b/platform/namespaces/default-serviceaccounts.yaml
@@ -59,6 +59,20 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: default
+  namespace: listings-ingest
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: mia
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
   namespace: oracle
 automountServiceAccountToken: false
 ---


### PR DESCRIPTION
## Summary

Adds `listings-ingest` and `mia` to `platform/namespaces/default-serviceaccounts.yaml`, disabling `automountServiceAccountToken` on their `default` ServiceAccounts — consistent with oracle, panchito, rigoberta, and all platform namespaces.

Both were missing from the list. `listings-ingest` was newly created; `mia` was an existing gap.