### PR TITLE
debug(airflow): keep failed worker pods for log inspection

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -43,6 +43,9 @@ spec:
         value: "listings-ingest"
       - name: ETL_IMAGE
         value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:881cd83b940f30a6e63b9ad8e86ba7e53a103fcd7814c21c07e50c8e1ae4ab43"
+      # temporary: keep failed worker pods for log inspection, remove after smoke test
+      - name: AIRFLOW__KUBERNETES__DELETE_WORKER_PODS_ON_FAILURE
+        value: "False"
 
     # External PostgreSQL configuration
     postgresql:


### PR DESCRIPTION
Temporary debugging aid. Sets `AIRFLOW__KUBERNETES__DELETE_WORKER_PODS_ON_FAILURE=False` so failed KubernetesExecutor worker pods remain in the `platform` namespace for log inspection.

**Remove this PR once the hello_k8s smoke test is passing.**

After merging and FluxCD reconciling, trigger `hello_k8s`, then:

```bash
kubectl get pods -n platform | grep hello-k8s
kubectl logs <pod-name> -n platform -c base
```