### PR TITLE
fix(rbac): add airflow-worker SA to pod-manager ClusterRoleBinding

### DIFF
--- a/platform/services/airflow/rbac.yaml
+++ b/platform/services/airflow/rbac.yaml
@@ -51,3 +51,6 @@ subjects:
   - kind: ServiceAccount
     name: airflow
     namespace: platform
+  - kind: ServiceAccount
+    name: airflow-worker
+    namespace: platform


### PR DESCRIPTION
## Root cause

KubernetesExecutor worker pods run as `system:serviceaccount:platform:airflow-worker`, not `airflow`. The `airflow-pod-manager` ClusterRoleBinding only covered `airflow`, so KubernetesPodOperator failed with 403 when trying to `list pods` in `listings-ingest` before even creating the pod.

## Fix

Adds `airflow-worker` as a second subject on the existing ClusterRoleBinding. No new role needed — the existing `airflow-pod-manager` ClusterRole already has the correct rules.

Closes #188 (item 3 — RBAC)