### PR TITLE
feat(listings-ingest): add ghcr-secret ExternalSecret and imagePullSecrets on SA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ secret.yml
 # BUT allow sealed secrets
 !*sealed-secret.yaml
 !*sealed-secret.yml
+# AND allow ExternalSecret manifests (these reference secret paths, not secret values)
+!*external-secret.yaml
+!*external-secret.yml
+!*.externalsecret.yaml
 *.enc.yaml
 *.enc.yml
 

--- a/tenants/listings-ingest/ghcr-secret.external-secret.yaml
+++ b/tenants/listings-ingest/ghcr-secret.external-secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ghcr-secret
+  namespace: listings-ingest
+  labels:
+    zave.io/workload: listings-ingest
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: ghcr-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      type: kubernetes.io/dockerconfigjson
+  data:
+    - secretKey: .dockerconfigjson
+      remoteRef:
+        key: platform/ghcr
+        property: .dockerconfigjson

--- a/tenants/listings-ingest/kustomization.yaml
+++ b/tenants/listings-ingest/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - serviceaccount.yaml
+  - ghcr-secret.external-secret.yaml
   - listings-ingest-db.externalsecret.yaml

--- a/tenants/listings-ingest/serviceaccount.yaml
+++ b/tenants/listings-ingest/serviceaccount.yaml
@@ -10,3 +10,5 @@ metadata:
   labels:
     zave.io/workload: listings-ingest
 automountServiceAccountToken: true
+imagePullSecrets:
+  - name: ghcr-secret


### PR DESCRIPTION
## Summary

Follows the oracle/panchito/rigoberta pattern for GHCR image pull auth:

- Adds `ghcr-secret.external-secret.yaml` sourcing `.dockerconfigjson` from Vault at `tenants/listings-ingest/ghcr`
- Wires `imagePullSecrets: [{name: ghcr-secret}]` onto the `listings-ingest` ServiceAccount so pods inherit pull credentials automatically

## Prerequisites (cluster-side, not in this PR)

- Vault secret provisioned at `tenants/listings-ingest/ghcr` with `.dockerconfigjson` property
- Vault policy granting ESO read access to `tenants/listings-ingest/*`

Until Vault is configured, use a temporary manual secret to unblock the smoke test:
```bash
kubectl create secret docker-registry ghcr-secret \
  --docker-server=ghcr.io \
  --docker-username=<github-username> \
  --docker-password=<ghcr-pat> \
  -n listings-ingest
```