### PR TITLE
fix(airflow): update etl-runner digest to image without OCI attestations

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
       - name: AIRFLOW_RUN_NAMESPACE
         value: "listings-ingest"
       - name: ETL_IMAGE
-        value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:881cd83b940f30a6e63b9ad8e86ba7e53a103fcd7814c21c07e50c8e1ae4ab43"
+        value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:73952e2991c46758a509d532c544a52d9dec16caa5ceb39d80223d453b5036fb"
       # temporary: keep failed worker pods for log inspection, remove after smoke test
       - name: AIRFLOW__KUBERNETES__DELETE_WORKER_PODS_ON_FAILURE
         value: "False"


### PR DESCRIPTION
## Summary

Updates `ETL_IMAGE` to the digest built after zavestudios/platform-pipelines#62, which made `provenance` and `sbom` default to `false`. The previous digest included OCI attestation artifacts in the image index, causing containerd (k3s) to fail with:

```
mismatched image rootfs and manifest layers
```

New digest: `sha256:73952e2991c46758a509d532c544a52d9dec16caa5ceb39d80223d453b5036fb`

Relates to zavestudios/gitops#188