### PR TITLE
fix(airflow): update etl-runner to python:3.11-slim build

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
       - name: AIRFLOW_RUN_NAMESPACE
         value: "listings-ingest"
       - name: ETL_IMAGE
-        value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:73952e2991c46758a509d532c544a52d9dec16caa5ceb39d80223d453b5036fb"
+        value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:f7ef312a5db7379af01c0dcbbaf789373465434621a73454edd26bfaeaa42dff"
       # temporary: keep failed worker pods for log inspection, remove after smoke test
       - name: AIRFLOW__KUBERNETES__DELETE_WORKER_PODS_ON_FAILURE
         value: "False"


### PR DESCRIPTION
## Summary

- Updates `ETL_IMAGE` digest to the python:3.11-slim build of zavestudios-etl-runner
- Previous distroless image caused `mismatched image rootfs and manifest layers` at pod startup due to OCI layer media type incompatibility with the k3s containerd version
- listings-ingest PR #28 fixed the Dockerfile; this wires in the resulting image

## Test plan

- [ ] Merge → FluxCD reconciles → Airflow Helm upgrade picks up new env var
- [ ] Re-trigger `hello_k8s` DAG
- [ ] Pod reaches Running state and logs `hello from kubernetes pod operator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)