### PR TITLE
chore: post smoke-test cleanup

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -43,9 +43,6 @@ spec:
         value: "listings-ingest"
       - name: ETL_IMAGE
         value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:f7ef312a5db7379af01c0dcbbaf789373465434621a73454edd26bfaeaa42dff"
-      # temporary: keep failed worker pods for log inspection, remove after smoke test
-      - name: AIRFLOW__KUBERNETES__DELETE_WORKER_PODS_ON_FAILURE
-        value: "False"
 
     # External PostgreSQL configuration
     postgresql:

--- a/tenants/listings-ingest/serviceaccount.yaml
+++ b/tenants/listings-ingest/serviceaccount.yaml
@@ -9,6 +9,6 @@ metadata:
     eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/listings-ingest-secrets-reader
   labels:
     zave.io/workload: listings-ingest
-automountServiceAccountToken: true
+automountServiceAccountToken: false
 imagePullSecrets:
   - name: ghcr-secret


### PR DESCRIPTION
## Summary

- Removes `AIRFLOW__KUBERNETES__DELETE_WORKER_PODS_ON_FAILURE=False` debug env var — `hello_k8s` smoke test passed, no longer needed
- Sets `automountServiceAccountToken: false` on `listings-ingest` ServiceAccount — resolves `disallow-auto-mount-service-account-token` Kyverno PolicyViolation

## Test plan

- [ ] Merge → FluxCD reconciles
- [ ] No `PolicyViolation` events on `serviceaccount/listings-ingest` in `kubectl get events -n listings-ingest`
- [ ] `hello_k8s` DAG continues to succeed on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)