### PR TITLE
Add rigoberta ServiceMonitor for metrics scraping

### DIFF
--- a/tenants/rigoberta/kustomization.yaml
+++ b/tenants/rigoberta/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - rigoberta-db.external-secret.yaml
   - deployment.yaml
   - service.yaml
+  - servicemonitor.yaml
 
 commonLabels:
   zave.io/workload: rigoberta

--- a/tenants/rigoberta/servicemonitor.yaml
+++ b/tenants/rigoberta/servicemonitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: rigoberta
+  namespace: rigoberta
+  labels:
+    app: rigoberta
+    release: monitoring
+    zave.io/workload: rigoberta
+spec:
+  selector:
+    matchLabels:
+      app: rigoberta
+      zave.io/workload: rigoberta
+  namespaceSelector:
+    matchNames:
+      - rigoberta
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s


### PR DESCRIPTION
## Summary

- add a `ServiceMonitor` for `rigoberta`
- wire it into the tenant kustomization
- move `rigoberta` toward the Formation standard for `capabilities: [{ name: metrics }]`

## Related

- Refs `zavestudios/gitops#190`
- Follow-on doctrine work: `zavestudios/platform-docs#77`

## Testing

- `kubectl kustomize tenants/rigoberta`
- confirmed rendered output includes `kind: ServiceMonitor`, `port: metrics`, and `path: /metrics`

## Manual Verification

**Requires cluster access:**
- verify the `ServiceMonitor` appears in namespace `rigoberta` after reconciliation
- verify Prometheus discovers and scrapes the `rigoberta` target
