### PR TITLE
Restore Prometheus Kubernetes service discovery

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -610,7 +610,8 @@ monitoring:
             registry: quay.io
             repository: prometheus/prometheus
           serviceAccountName: prometheus-monitoring-monitoring-kube-prometheus
-          automountServiceAccountToken: false  # Disable for Kyverno policy compliance
+          # Prometheus needs Kubernetes API credentials for ServiceMonitor/PodMonitor discovery.
+          automountServiceAccountToken: true
           resources:
             requests:
               memory: 512Mi

--- a/platform/policies/kyverno/enforce/bigbang/disallow-auto-mount-service-account-token.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/disallow-auto-mount-service-account-token.yaml
@@ -32,6 +32,11 @@ spec:
       - resources:
           namespaces:
           - kube-system
+      - resources:
+          namespaces:
+          - monitoring
+          names:
+          - prometheus-monitoring-monitoring-kube-prometheus*
     match:
       all:
       - resources:
@@ -55,6 +60,11 @@ spec:
       - resources:
           namespaces:
           - kube-system
+      - resources:
+          namespaces:
+          - monitoring
+          names:
+          - prometheus-monitoring-monitoring-kube-prometheus
     match:
       all:
       - resources:


### PR DESCRIPTION
## Summary

- enable the Prometheus service account token mount
- allow the Prometheus workload to opt out of the broad automount audit policy
- restore Kubernetes service discovery for `ServiceMonitor`/`PodMonitor` targets

## Why

`rigoberta` now has a valid `ServiceMonitor`, and Prometheus renders the scrape job into its live config, but the Prometheus pod was configured with `automountServiceAccountToken: false`.

That leaves Prometheus able to load scrape configuration but unable to use Kubernetes service discovery at runtime, which explains why the live Targets API only exposed the static Vault target.

## Related

- Refs `zavestudios/gitops#190`
- Follow-on doctrine work: `zavestudios/platform-docs#77`

## Manual Verification

**Requires cluster access:**
- verify the Prometheus pod gets a mounted service account token after reconciliation
- verify `up{namespace="rigoberta",job="rigoberta"}` returns `1`
- verify additional Kubernetes-discovered scrape targets appear in the Prometheus Targets UI
