### PR TITLE
Enable Alloy OTLP receiver for tenant tracing

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -858,6 +858,14 @@ alloy:
             repository: grafana/alloy
             tag: "v1.12.2"
     upstream:
+      applicationObservability:
+        enabled: true
+        receivers:
+          otlp:
+            grpc:
+              enabled: true
+            http:
+              enabled: true
       alloy-operator:
         waitForAlloyRemoval:
           image:
@@ -887,6 +895,12 @@ alloy:
         - name: loki
           type: loki
           url: http://logging-loki.logging.svc.cluster.local:3100/loki/api/v1/push
+        - name: tempo
+          type: otlp
+          protocol: grpc
+          url: tempo-tempo.tempo.svc.cluster.local:4317
+          traces:
+            enabled: true
 
 # Loki - log aggregation storage
 loki:


### PR DESCRIPTION
## Summary

- enable Alloy application observability receivers for OTLP gRPC and HTTP
- add a traces-only OTLP destination pointing at the in-cluster Tempo service
- publish the missing platform-owned tracing path required before wiring `mia`

## Why

The observability doctrine now defines the Formation tracing path as:

`workload -> Alloy receiver -> Tempo`

Live cluster checks showed that path was not actually consumable yet:

- the `alloy` namespace only exposed `alloy-alloy-logs` and `alloy-alloy-operator`
- there was no receiver `Service` for tenant OTLP traffic
- Tempo is already present and exposes OTLP ports in-cluster

This PR closes the platform half of that gap.

## Related

- Refs `zavestudios/gitops#190`
- Refs `zavestudios/platform-docs#77`
- Depends on the observability doctrine in `zavestudios/platform-docs#78`

## Manual Verification

**Requires cluster access:**
- verify a receiver `Service` appears in namespace `alloy`
- verify the receiver exposes OTLP ports `4317` and/or `4318`
- verify Alloy forwards traces to `tempo-tempo.tempo.svc.cluster.local`
- after that, wire `mia` to the published receiver endpoint and verify traces in Tempo
