### PR TITLE
Enable Alloy OTLP receiver for application traces

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -858,6 +858,21 @@ alloy:
             repository: grafana/alloy
             tag: "v1.12.2"
     upstream:
+      collectors:
+        receiver:
+          presets:
+            - daemonset
+      applicationObservability:
+        enabled: true
+        collector: receiver
+        receivers:
+          otlp:
+            grpc:
+              enabled: true
+              port: 4317
+            http:
+              enabled: true
+              port: 4318
       alloy-operator:
         waitForAlloyRemoval:
           image:
@@ -887,6 +902,12 @@ alloy:
         - name: loki
           type: loki
           url: http://logging-loki.logging.svc.cluster.local:3100/loki/api/v1/push
+        - name: tempo
+          type: otlp
+          protocol: grpc
+          url: tempo-tempo.tempo.svc.cluster.local:4317
+          traces:
+            enabled: true
 
 # Loki - log aggregation storage
 loki:


### PR DESCRIPTION
Enable application OTLP receivers in the Alloy package and add a traces destination to the in-cluster Tempo service so tenant workloads have a platform-owned tracing path.

Refs zavestudios/gitops#190
Refs zavestudios/platform-docs#77

🤖 Generated with [Claude Code](https://claude.com/claude-code)