### PR TITLE
Harden Alloy finalizer hook without broad policy exceptions

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -775,14 +775,39 @@ alloy:
                   metadata:
                     labels:
                       app.kubernetes.io/version: "0.1.2"
+                      sidecar.istio.io/inject: "true"
                     annotations:
                       sidecar.istio.io/inject: "true"
                   spec:
                     automountServiceAccountToken: false
                     imagePullSecrets: []
+                    volumes:
+                      - name: k8s-api-access
+                        projected:
+                          defaultMode: 420
+                          sources:
+                            - serviceAccountToken:
+                                audience: https://kubernetes.default.svc
+                                expirationSeconds: 3600
+                                path: token
+                            - configMap:
+                                items:
+                                  - key: ca.crt
+                                    path: ca.crt
+                                name: kube-root-ca.crt
+                            - downwardAPI:
+                                items:
+                                  - fieldRef:
+                                      apiVersion: v1
+                                      fieldPath: metadata.namespace
+                                    path: namespace
                     containers:
                       - name: add-finalizers
                         image: ghcr.io/grafana/helm-chart-toolbox-kubectl:0.1.2
+                        volumeMounts:
+                          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                            name: k8s-api-access
+                            readOnly: true
                     serviceAccountName: alloy-upstream-add-finalizer
           - target:
               group: v1


### PR DESCRIPTION
## Summary

- keep `automountServiceAccountToken: false` on the Alloy finalizer hook job
- project a short-lived service account token volume into the hook pod at the standard Kubernetes API credential path
- explicitly override the hook pod label path for `sidecar.istio.io/inject` to `"true"`

## Why

The Alloy OTLP receiver work progressed past values validation, but the `alloy-upstream-add-finalizer` post-upgrade hook is now blocked by policy:

- the hook needs Kubernetes API credentials to run `kubectl patch`
- the current hardened environment rejects auto-mounted service account tokens
- the hook pod also violates the current Istio injection-bypass rule because upstream renders `sidecar.istio.io/inject: "false"` on the pod label path

This PR takes the tighter path first:

- do not add a broad automount policy exception
- do not exempt the whole `alloy` namespace
- project only the credentials this hook needs
- override the hook pod label path so it no longer declares an injection bypass

## Related

- Refs `zavestudios/gitops#190`
- Follow-up to the Alloy receiver work in `#209`, `#210`, and `#212`

## Manual Verification

**Requires cluster access:**
- verify `HelmRelease/alloy` moves past the post-upgrade hook timeout
- verify the `alloy-upstream-add-finalizer` hook job can create a pod
- verify the hook pod mounts `/var/run/secrets/kubernetes.io/serviceaccount`
- verify the Alloy receiver service appears after a successful upgrade
