### PR TITLE
Exclude Alloy finalizer hook from local Kyverno blockers

### DIFF
--- a/platform/policies/kyverno/enforce/bigbang/disallow-auto-mount-service-account-token.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/disallow-auto-mount-service-account-token.yaml
@@ -37,6 +37,11 @@ spec:
           - monitoring
           names:
           - prometheus-monitoring-monitoring-kube-prometheus*
+      - resources:
+          namespaces:
+          - alloy
+          names:
+          - alloy-upstream-add-finalizer*
     match:
       all:
       - resources:
@@ -65,6 +70,11 @@ spec:
           - monitoring
           names:
           - prometheus-monitoring-monitoring-kube-prometheus
+      - resources:
+          namespaces:
+          - alloy
+          names:
+          - alloy-upstream-add-finalizer
     match:
       all:
       - resources:

--- a/platform/policies/kyverno/enforce/bigbang/restrict-image-registries.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-image-registries.yaml
@@ -37,6 +37,11 @@ spec:
       - resources:
           namespaces:
           - kube-system
+      - resources:
+          namespaces:
+          - alloy
+          names:
+          - alloy-upstream-add-finalizer*
     match:
       all:
       - resources:


### PR DESCRIPTION
## Summary

- add a narrow exclusion for `alloy-upstream-add-finalizer*` in the local `restrict-image-registries` policy
- add a narrow exclusion for the same hook pod/job prefix and hook service account in the local `disallow-auto-mount-service-account-token` policy

## Why

Live cluster evidence showed the Alloy upgrade is now blocked by the `alloy-upstream-add-finalizer` post-upgrade hook path.

Two of the current denials are definitely repo-owned:

- `restrict-image-registries`
- `disallow-auto-mount-service-account-token`

This PR excludes only the hook path needed to let the Alloy package complete its upgrade. The exclusions are limited to:

- namespace: `alloy`
- pod/job name prefix: `alloy-upstream-add-finalizer*`
- service account: `alloy-upstream-add-finalizer`

## Important Note

The observed `sidecar.istio.io/inject` denial is not sourced from the local Kyverno policy snapshot in this repo, so that specific blocker may still require a separate fix outside these two policies.

## Related

- Refs `zavestudios/gitops#190`
- Follow-up to Alloy receiver work in `#209`, `#210`, `#212`, and `#213`

## Manual Verification

**Requires cluster access:**
- verify the hook job gets past local image-registry and automount denials
- verify whether an Istio injection-bypass denial still remains
- verify `HelmRelease/alloy` becomes `Ready=True`
- verify the Alloy receiver service appears in namespace `alloy`
