### PR TITLE
Exclude Alloy hook in live kyverno-policies values

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -156,6 +156,28 @@ kyvernoPolicies:
             - index.docker.io/    # Docker Hub canonical hostname
             - registry.k8s.io/    # Kubernetes registry
             - public.ecr.aws/     # AWS Public ECR
+        exclude:
+          any:
+            - resources:
+                namespaces:
+                  - alloy
+                names:
+                  - alloy-upstream-add-finalizer*
+      disallow-auto-mount-service-account-token:
+        exclude:
+          any:
+            - resources:
+                namespaces:
+                  - alloy
+                names:
+                  - alloy-upstream-add-finalizer*
+            - resources:
+                namespaces:
+                  - alloy
+                kinds:
+                  - ServiceAccount
+                names:
+                  - alloy-upstream-add-finalizer
 
 eckOperator:
   enabled: false


### PR DESCRIPTION
## Summary

- add a narrow `restrict-image-registries` exclusion for `alloy-upstream-add-finalizer*`
- add a narrow `disallow-auto-mount-service-account-token` exclusion for the same hook path and hook service account
- patch the actual Big Bang `kyvernoPolicies` values surface that currently drives the live enforcing policies

## Why

Live cluster inspection showed a governance mismatch:

- vendored policy files under `platform/policies/kyverno/enforce/bigbang/` exist locally
- but the active `restrict-image-registries` ClusterPolicy is still being generated from the Big Bang `kyvernoPolicies` package
- editing the vendored snapshot alone does not change the live blocker today

This PR targets the real runtime authority so the Alloy finalizer hook can progress.

## Scope

This does **not** resolve the longer-term authority bug around vendored policies not being the live source of truth. It only unblocks the current runtime path.

## Related

- Refs `zavestudios/gitops#190`
- Follows the Alloy hook and OTLP receiver work across `#209`, `#210`, `#212`, `#213`, and `#214`

## Manual Verification

**Requires cluster access:**
- verify the live `restrict-image-registries` ClusterPolicy now contains the Alloy hook exclusion
- verify the live `disallow-auto-mount-service-account-token` ClusterPolicy now contains the Alloy hook exclusion
- verify the Alloy finalizer hook gets past those denials
- verify whether any remaining blocker is only the separate Istio injection-bypass policy
