### PR TITLE
Add durable Alloy finalizer hook RBAC

### DIFF
--- a/platform/runtime/alloy-hook-support/kustomization.yaml
+++ b/platform/runtime/alloy-hook-support/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - serviceaccount.yaml
+  - role.yaml
+  - rolebinding.yaml

--- a/platform/runtime/alloy-hook-support/role.yaml
+++ b/platform/runtime/alloy-hook-support/role.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: alloy-upstream-add-finalizer
+  namespace: alloy
+  labels:
+    app.kubernetes.io/name: alloy-upstream-add-finalizer
+    app.kubernetes.io/part-of: alloy
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    resourceNames:
+      - alloy-alloy-operator
+    verbs:
+      - get
+      - patch
+      - update

--- a/platform/runtime/alloy-hook-support/rolebinding.yaml
+++ b/platform/runtime/alloy-hook-support/rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: alloy-upstream-add-finalizer
+  namespace: alloy
+  labels:
+    app.kubernetes.io/name: alloy-upstream-add-finalizer
+    app.kubernetes.io/part-of: alloy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: alloy-upstream-add-finalizer
+subjects:
+  - kind: ServiceAccount
+    name: alloy-upstream-add-finalizer
+    namespace: alloy

--- a/platform/runtime/alloy-hook-support/serviceaccount.yaml
+++ b/platform/runtime/alloy-hook-support/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy-upstream-add-finalizer
+  namespace: alloy
+  labels:
+    app.kubernetes.io/name: alloy-upstream-add-finalizer
+    app.kubernetes.io/part-of: alloy
+automountServiceAccountToken: true

--- a/platform/runtime/kustomization.yaml
+++ b/platform/runtime/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../vault/
   - ../policies/kyverno/
+  - alloy-hook-support/
 
   # ArgoCD platform resources and tenant Application registrations
   - ../argocd/


### PR DESCRIPTION
## Summary
- pre-create the Alloy finalizer hook ServiceAccount, Role, and RoleBinding in Flux-managed runtime state
- wire the new hook support bundle into `platform/runtime`
- keep the fix scoped to the upstream hook lifecycle failure blocking Alloy reconciliation

## Context
This follows `gitops#190` tracing enablement work. The current runtime blocker is not OTLP config or Kyverno policy anymore; the Helm hook Job exists but its `ServiceAccount`/RBAC resources are absent at execution time, so the hook pod cannot start.

## Validation
- `kubectl kustomize /Users/xavierlopez/Dev/gitops/platform/runtime`

## Manual steps
- **Requires cluster access:** wait for Flux to reconcile `platform/runtime`
- **Requires cluster access:** verify `kubectl get sa,role,rolebinding -n alloy | grep alloy-upstream-add-finalizer`
- **Requires cluster access:** verify `kubectl get hr -n bigbang alloy`
- **Requires cluster access:** verify a receiver Service appears with `kubectl get svc -n alloy`