### PR TITLE
Disable Alloy Helm hooks

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -744,6 +744,11 @@ tempo:
 # Alloy - unified observability collector
 alloy:
   enabled: true
+  flux:
+    install:
+      disableHooks: true
+    upgrade:
+      disableHooks: true
   postRenderers:
     - kustomize:
         patches:


### PR DESCRIPTION
## Summary
- disable Alloy Helm install and upgrade hooks in the Big Bang package wrapper
- keep the earlier durable hook RBAC and values-path work on the same branch for traceability, but this PR specifically unblocks the current hook timeout by skipping hooks entirely

## Context
This follows `gitops#190` tracing enablement work. The Alloy package is currently blocked by a post-upgrade hook that continues to render with an invalid image reference and an Istio-injection-bypass label outside the reliable control path of our wrapper patches. Disabling hooks matches the existing Big Bang pattern already used for Istio packages in this repo.

## Validation
- repo diff inspection only

## Manual steps
- **Requires cluster access:** merge this PR
- **Requires cluster access:** wait for `on-prem-bigbang` to reconcile
- **Requires cluster access:** verify `kubectl get hr -n bigbang alloy`
- **Requires cluster access:** verify `kubectl get svc -n alloy`
- **Requires cluster access:** if Alloy becomes healthy, continue with receiver verification and `mia` tracing wiring