### PR TITLE
Define Alloy receiver collector

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -872,14 +872,16 @@ alloy:
           http:
             enabled: true
             port: 4318
-    alloy-receiver:
-      enabled: true
     global:
       imageRegistry: ""  # Disable top-level registry prepending
       imagePullSecrets: []
       image:
         registry: ""
         pullSecrets: []
+    collectors:
+      alloy-receiver:
+        presets:
+          - deployment
     k8s-monitoring:
       alloy-logs:
         image:


### PR DESCRIPTION
## Summary
- replace the non-effective top-level `alloy-receiver.enabled` flag
- define `collectors.alloy-receiver` with the deployment preset the upstream chart expects
- keep application observability pointed at `collector: alloy-receiver`

## Context
The Alloy HelmRelease is now healthy, but no receiver workload or Service materializes. The rendered values secret shows the feature flags are landing, but upstream examples and collector values indicate the chart expects a collector definition under `collectors.alloy-receiver`, not just `alloy-receiver.enabled`.

## Validation
- primary source check against upstream `grafana/k8s-monitoring-helm` example:
  `docs/examples/features/application-observability/default/values.yaml`

## Manual steps
- **Requires cluster access:** merge this PR
- **Requires cluster access:** wait for `on-prem-bigbang` / Alloy to reconcile
- **Requires cluster access:** verify `kubectl get alloys -n alloy`
- **Requires cluster access:** verify `kubectl get deployment,svc -n alloy | grep receiver`