### PR TITLE
Add explicit Alloy receiver runtime

### DIFF
--- a/platform/runtime/alloy-receiver/alloy.yaml
+++ b/platform/runtime/alloy-receiver/alloy.yaml
@@ -1,0 +1,58 @@
+apiVersion: collectors.grafana.com/v1alpha1
+kind: Alloy
+metadata:
+  name: alloy-receiver
+  namespace: alloy
+  labels:
+    app.kubernetes.io/name: alloy-receiver
+    app.kubernetes.io/part-of: alloy
+spec:
+  nameOverride: alloy-receiver
+  crds:
+    create: false
+  alloy:
+    configMap:
+      create: false
+      name: alloy-receiver
+      key: config.alloy
+    enableHttpServerPort: true
+    extraPorts:
+      - name: otlp-grpc
+        port: 4317
+        targetPort: 4317
+        protocol: TCP
+      - name: otlp-http
+        port: 4318
+        targetPort: 4318
+        protocol: TCP
+        appProtocol: http
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+          - CHOWN
+          - DAC_OVERRIDE
+          - FOWNER
+          - FSETID
+          - KILL
+          - SETGID
+          - SETUID
+          - SETPCAP
+          - NET_BIND_SERVICE
+          - NET_RAW
+          - SYS_CHROOT
+          - MKNOD
+          - AUDIT_WRITE
+          - SETFCAP
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  controller:
+    type: deployment
+    replicas: 1
+    nodeSelector:
+      kubernetes.io/os: linux
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy

--- a/platform/runtime/alloy-receiver/configmap.yaml
+++ b/platform/runtime/alloy-receiver/configmap.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-receiver
+  namespace: alloy
+  labels:
+    app.kubernetes.io/name: alloy-receiver
+    app.kubernetes.io/part-of: alloy
+data:
+  config.alloy: |
+    otelcol.receiver.otlp "receiver" {
+      grpc {
+        endpoint = "0.0.0.0:4317"
+      }
+
+      http {
+        endpoint = "0.0.0.0:4318"
+        include_metadata = false
+        max_request_body_size = "20MiB"
+      }
+
+      output {
+        traces = [otelcol.processor.batch.default.input]
+      }
+    }
+
+    otelcol.processor.batch "default" {
+      send_batch_size = 8192
+      send_batch_max_size = 0
+      timeout = "2s"
+
+      output {
+        traces = [otelcol.exporter.otlp.tempo.input]
+      }
+    }
+
+    otelcol.exporter.otlp "tempo" {
+      client {
+        endpoint = "tempo-tempo.tempo.svc.cluster.local:4317"
+
+        tls {
+          insecure = true
+          insecure_skip_verify = true
+        }
+      }
+
+      retry_on_failure {
+        enabled = true
+        initial_interval = "5s"
+        max_interval = "30s"
+        max_elapsed_time = "5m"
+      }
+
+      sending_queue {
+        enabled = true
+      }
+    }

--- a/platform/runtime/alloy-receiver/kustomization.yaml
+++ b/platform/runtime/alloy-receiver/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - configmap.yaml
+  - alloy.yaml

--- a/platform/runtime/kustomization.yaml
+++ b/platform/runtime/kustomization.yaml
@@ -2,9 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - alloy-receiver/
+  - alloy-hook-support/
   - ../vault/
   - ../policies/kyverno/
-  - alloy-hook-support/
 
   # ArgoCD platform resources and tenant Application registrations
   - ../argocd/


### PR DESCRIPTION
## Summary
- add an explicit `platform/runtime/alloy-receiver` bundle with a ConfigMap and Alloy CR
- wire the new receiver bundle into `platform/runtime`
- route OTLP traces from the receiver to `tempo-tempo.tempo.svc.cluster.local:4317`

## Context
The Big Bang Alloy package is now healthy, and the values for application observability and `collectors.alloy-receiver` are landing. However, the rendered release still only creates the logs collector. The release manifest references `alloy-receiver` in ancillary resources like network policies, but does not create the receiver ConfigMap or Alloy CR. This PR flattens just that slice into explicit GitOps-managed runtime state.

## Validation
- `kubectl kustomize /Users/xavierlopez/Dev/gitops/platform/runtime`
- upstream example review from `grafana/k8s-monitoring-helm` application-observability output

## Manual steps
- **Requires cluster access:** merge this PR
- **Requires cluster access:** wait for `on-prem-platform-runtime` to reconcile
- **Requires cluster access:** verify `kubectl get alloys -n alloy`
- **Requires cluster access:** verify `kubectl get deployment,svc -n alloy | grep receiver`
- **Requires cluster access:** once the receiver exists, wire `mia` to the OTLP endpoint and validate traces in Tempo