### PR TITLE
Harden Alloy receiver security context

### DIFF
--- a/platform/runtime/alloy-receiver/alloy.yaml
+++ b/platform/runtime/alloy-receiver/alloy.yaml
@@ -30,21 +30,6 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        add:
-          - CHOWN
-          - DAC_OVERRIDE
-          - FOWNER
-          - FSETID
-          - KILL
-          - SETGID
-          - SETUID
-          - SETPCAP
-          - NET_BIND_SERVICE
-          - NET_RAW
-          - SYS_CHROOT
-          - MKNOD
-          - AUDIT_WRITE
-          - SETFCAP
         drop:
           - ALL
       seccompProfile:


### PR DESCRIPTION
## Summary
- remove unnecessary added Linux capabilities from the explicit `alloy-receiver` runtime spec
- keep `drop: [ALL]` and `allowPrivilegeEscalation: false`
- align the receiver with the enforced Kyverno `require-drop-all-capabilities` policy

## Context
The explicit `alloy-receiver` ConfigMap and Alloy CR from `#220` are now applying, but the operator-generated Deployment is blocked by Kyverno because the receiver security context still carried the upstream capability additions. The receiver only needs ports `4317` and `4318`, so those extra capabilities are unnecessary.

## Validation
- `kubectl kustomize /Users/xavierlopez/Dev/gitops/platform/runtime`

## Manual steps
- **Requires cluster access:** merge this PR
- **Requires cluster access:** wait for `on-prem-platform-runtime` to reconcile
- **Requires cluster access:** verify `kubectl describe alloy -n alloy alloy-receiver`
- **Requires cluster access:** verify `kubectl get deployment,svc -n alloy | grep alloy-receiver`