### PR TITLE
Exclude Alloy receiver from automount policy

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -175,6 +175,13 @@ kyvernoPolicies:
                 namespaces:
                   - alloy
                 kinds:
+                  - Deployment
+                names:
+                  - alloy-receiver
+            - resources:
+                namespaces:
+                  - alloy
+                kinds:
                   - ServiceAccount
                 names:
                   - alloy-upstream-add-finalizer


### PR DESCRIPTION
## Summary
- add a narrow live `kyvernoPolicies` exclusion for `Deployment/alloy-receiver`
- scope the exclusion to namespace `alloy` and the single deployment name
- leave the existing finalizer-hook exclusions untouched

## Context
The explicit `alloy-receiver` Alloy CR is now applying and the operator is attempting to create `Deployment/alloy-receiver`. The remaining admission blocker is the live `disallow-auto-mount-service-account-token` policy on the operator-generated deployment. This deployment is outside a reliable direct patch surface in GitOps, so the smallest pragmatic step is a deployment-specific exclusion.

## Manual steps
- **Requires cluster access:** merge this PR
- **Requires cluster access:** wait for `on-prem-bigbang` and `kyvernoPolicies` to reconcile
- **Requires cluster access:** verify the live automount policy includes the `alloy-receiver` exclusion
- **Requires cluster access:** verify `kubectl get deployment,svc -n alloy | grep alloy-receiver`