### PR TITLE
Disable wedged Kyverno automount update policy

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -146,6 +146,8 @@ kyvernoPolicies:
       scripts:
         image: registry.k8s.io/kubectl:v1.34.3
     policies:
+      update-automountserviceaccounttokens:
+        enabled: false
       restrict-image-registries:
         parameters:
           allow:


### PR DESCRIPTION
## Summary
Disable the `update-automountserviceaccounttokens` policy in the live Big Bang `kyvernoPolicies` values path.

## Why
`kyverno-policies` is currently wedged during upgrade while patching `ClusterPolicy/update-automountserviceaccounttokens`. Kyverno's validating webhook is timing out on that policy update, which prevents the release from reconciling and blocks the narrower Alloy receiver automount exclusion from landing.

This change reduces the upgrade surface so `kyverno-policies` can reconcile again.

## Change
- set `kyvernoPolicies.values.policies.update-automountserviceaccounttokens.enabled = false`

## Manual verification
- Force or wait for `HelmRelease/bigbang/kyverno-policies` to reconcile successfully
- Confirm the live `disallow-auto-mount-service-account-token` policy includes the `alloy-receiver` exclusion
- Confirm `Deployment/Service alloy-receiver` can then materialize

**Requires cluster access:**
```bash
kubectl get hr -n bigbang kyverno-policies
kubectl get cpol disallow-auto-mount-service-account-token -o json | jq '.spec.rules[] | {name, exclude}'
kubectl get deployment,svc -n alloy | grep alloy-receiver
```
