### PR TITLE
Add inactive Big Bang split manifests

### DIFF
--- a/bigbang/foundation/helmrelease.yaml
+++ b/bigbang/foundation/helmrelease.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bigbang-foundation
+  namespace: bigbang
+spec:
+  interval: 10m
+  driftDetection:
+    mode: enabled
+  chart:
+    spec:
+      chart: ./chart
+      sourceRef:
+        kind: GitRepository
+        name: bigbang
+        namespace: bigbang
+      interval: 10m
+  timeout: 20m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: bigbang-foundation-values
+      valuesKey: values.yaml

--- a/bigbang/foundation/kustomization.yaml
+++ b/bigbang/foundation/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+
+configurations:
+  - kustomizeconfig.yaml
+
+configMapGenerator:
+  - name: bigbang-foundation-values
+    namespace: bigbang
+    files:
+      - values.yaml=values-foundation.yaml

--- a/bigbang/foundation/kustomizeconfig.yaml
+++ b/bigbang/foundation/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+# Teach Kustomize to rewrite ConfigMap references in Flux HelmRelease CRDs
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -1,0 +1,480 @@
+# Big Bang foundation values for on-prem environment
+# Mesh, ingress, secrets, identity, app delivery, and Kiali stay together in
+# the first split so downstream dependencies remain narrow but legible.
+
+domain: zavestudios.com
+
+gatekeeper:
+  enabled: false
+
+bbctl:
+  enabled: false
+
+kyverno:
+  enabled: false
+
+kyvernoReporter:
+  enabled: false
+
+kyvernoPolicies:
+  enabled: false
+
+eckOperator:
+  enabled: false
+
+elasticsearchKibana:
+  enabled: false
+
+fluentbit:
+  enabled: false
+
+neuvector:
+  enabled: false
+
+twistlock:
+  enabled: false
+
+istioCRDs:
+  enabled: true
+
+istiod:
+  enabled: true
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              namespace: istio-system
+              name: istiod
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: istiod
+              spec:
+                template:
+                  spec:
+                    automountServiceAccountToken: true
+  flux:
+    install:
+      disableHooks: true
+    upgrade:
+      disableHooks: true
+  values:
+    upstream:
+      global:
+        hub: docker.io/istio
+        tag: 1.28.3
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+
+istioGateway:
+  enabled: true
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              version: v1
+              kind: ServiceAccount
+              namespace: istio-gateway
+              name: public-ingressgateway-ingressgateway-service-account
+            patch: |
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: public-ingressgateway-ingressgateway-service-account
+              automountServiceAccountToken: false
+  flux:
+    install:
+      disableHooks: true
+    upgrade:
+      disableHooks: true
+  values:
+    gateways:
+      public:
+        gateway:
+          servers:
+            - hosts:
+                - '*.zavestudios.com'
+              port:
+                name: http
+                number: 8080
+                protocol: HTTP
+              tls:
+                httpsRedirect: false
+        upstream:
+          global:
+            hub: docker.io/istio
+            tag: 1.28.3
+      passthrough: {}
+
+addons:
+  gitlab:
+    enabled: false
+  gitlabRunner:
+    enabled: false
+  externalSecrets:
+    enabled: true
+    postRenderers:
+      - kustomize:
+          patches:
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: external-secrets
+                name: external-secrets
+              patch: |
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: external-secrets
+                spec:
+                  template:
+                    metadata:
+                      labels:
+                        app.kubernetes.io/version: "1.2.1"
+    values:
+      waitJob: false
+      upstream:
+        podLabels:
+          vault-ingress: "true"
+        image:
+          repository: ghcr.io/external-secrets/external-secrets
+          tag: v1.2.1
+        imagePullSecrets: []
+        webhook:
+          image:
+            repository: ghcr.io/external-secrets/external-secrets
+            tag: v1.2.1
+          imagePullSecrets: []
+        certController:
+          image:
+            repository: ghcr.io/external-secrets/external-secrets
+            tag: v1.2.1
+          imagePullSecrets: []
+  vault:
+    enabled: true
+    postRenderers:
+      - kustomize:
+          patches:
+            - target:
+                group: networking.istio.io
+                version: v1
+                kind: VirtualService
+                namespace: keycloak
+                name: keycloak
+              patch: |
+                - op: remove
+                  path: /spec/tls
+            - target:
+                group: apps
+                version: v1
+                kind: StatefulSet
+                namespace: vault
+                name: vault-vault
+              patch: |
+                apiVersion: apps/v1
+                kind: StatefulSet
+                metadata:
+                  name: vault-vault
+                spec:
+                  template:
+                    spec:
+                      automountServiceAccountToken: false
+    values:
+      global:
+        imageRegistry: ""
+      istio:
+        vault:
+          hosts:
+            - vault-on-prem.zavestudios.com
+      autoInit:
+        enabled: false
+      upstream:
+        server:
+          ha:
+            apiAddr: "http://vault.vault.svc.cluster.local:8200"
+          image:
+            repository: docker.io/hashicorp/vault
+            tag: 1.21.2
+          standalone:
+            config: |
+              ui = true
+              api_addr = "http://vault.vault.svc.cluster.local:8200"
+
+              seal "awskms" {
+                region     = "us-west-2"
+                kms_key_id = "alias/zavestudios-onprem-vault-auto-unseal"
+              }
+
+              listener "tcp" {
+                tls_disable = 1
+                address = "[::]:8200"
+                cluster_address = "[::]:8201"
+              }
+
+              telemetry {
+                prometheus_retention_time = "24h"
+                disable_hostname = true
+                unauthenticated_metrics_access = true
+              }
+
+              storage "file" {
+                path = "/vault/data"
+              }
+          serviceAccount:
+            create: true
+            automountServiceAccountToken: false
+          extraSecretEnvironmentVars:
+            - envName: AWS_ACCESS_KEY_ID
+              secretName: vault-aws-auto-unseal
+              secretKey: AWS_ACCESS_KEY_ID
+            - envName: AWS_SECRET_ACCESS_KEY
+              secretName: vault-aws-auto-unseal
+              secretKey: AWS_SECRET_ACCESS_KEY
+          statefulSet:
+            annotations:
+              kyverno.io/ignore: "false"
+          extraLabels:
+            app.kubernetes.io/version: "1.21.2"
+        injector:
+          enabled: false
+          image:
+            repository: docker.io/hashicorp/vault-k8s
+            tag: 1.7.3
+          agentImage:
+            repository: docker.io/hashicorp/vault
+            tag: 1.21.2
+          authDelegator:
+            enabled: false
+          serviceAccount:
+            create: true
+          automountServiceAccountToken: false
+          extraLabels:
+            app.kubernetes.io/version: "1.7.3"
+        csi:
+          enabled: false
+          image:
+            repository: docker.io/hashicorp/vault-csi-provider
+            tag: 1.7.0
+          serviceAccount:
+            create: true
+          automountServiceAccountToken: false
+          extraLabels:
+            app.kubernetes.io/version: "1.7.0"
+  keycloak:
+    enabled: true
+    hostname: sso-on-prem
+    ingress:
+      gateway: "public"
+      cert: ""
+      key: ""
+    values:
+      postgresql:
+        enabled: false
+      global:
+        imageRegistry: ""
+      istio:
+        keycloak:
+          hosts:
+            - sso-on-prem.zavestudios.com
+      upstream:
+        image:
+          repository: ghcr.io/zavestudios/keycloak
+          tag: bootstrap
+        podLabels:
+          app.kubernetes.io/version: "26.4.7"
+        automountServiceAccountToken: false
+        serviceAccount:
+          automountServiceAccountToken: false
+        args:
+          - start
+          - --optimized
+          - --http-enabled=true
+          - --proxy-headers=forwarded
+          - --hostname=https://sso-on-prem.zavestudios.com/auth
+          - --hostname-strict=false
+        replicas: 1
+        database:
+          vendor: postgres
+          hostname: "192.168.122.20"
+          port: 5432
+          database: "db_keycloak"
+          username: "keycloak_app"
+          existingSecret: "keycloak-postgres-credentials"
+          existingSecretKey: "KC_DB_PASSWORD"
+        extraEnvFrom: |
+          - secretRef:
+              name: keycloak-postgres-credentials
+          - secretRef:
+              name: keycloak-admin-credentials
+        extraVolumes: |
+          - name: keycloak-data
+            emptyDir: {}
+          - name: tmp
+            emptyDir: {}
+        extraVolumeMounts: |
+          - name: keycloak-data
+            mountPath: /opt/keycloak/data
+          - name: tmp
+            mountPath: /tmp
+    postRenderers:
+      - kustomize:
+          patches:
+            - target:
+                group: apps
+                version: v1
+                kind: StatefulSet
+                namespace: keycloak
+                labelSelector: app.kubernetes.io/instance=keycloak
+              patch: |
+                apiVersion: apps/v1
+                kind: StatefulSet
+                metadata:
+                  name: not-used
+                spec:
+                  template:
+                    spec:
+                      automountServiceAccountToken: false
+                      imagePullSecrets:
+                        - name: private-registry
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: keycloak
+                labelSelector: app.kubernetes.io/instance=keycloak
+              patch: |
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: not-used
+                spec:
+                  template:
+                    spec:
+                      automountServiceAccountToken: false
+                      imagePullSecrets:
+                        - name: private-registry
+  argocd:
+    enabled: true
+    postRenderers:
+      - kustomize:
+          patches:
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: argocd
+                labelSelector: app.kubernetes.io/instance=argocd-argocd
+              patch: |
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: not-used
+                spec:
+                  template:
+                    spec:
+                      automountServiceAccountToken: false
+            - target:
+                group: apps
+                version: v1
+                kind: StatefulSet
+                namespace: argocd
+                labelSelector: app.kubernetes.io/instance=argocd-argocd
+              patch: |
+                apiVersion: apps/v1
+                kind: StatefulSet
+                metadata:
+                  name: not-used
+                spec:
+                  template:
+                    spec:
+                      automountServiceAccountToken: false
+    values:
+      istio:
+        argocd:
+          hosts:
+            - argocd-on-prem.zavestudios.com
+      upgradeJob:
+        enabled: false
+      global:
+        image:
+          repository: quay.io/argoproj/argocd
+      upstream:
+        dex:
+          image:
+            repository: ghcr.io/dexidp/dex
+      redis-bb:
+        cleanUpgrade:
+          enabled: false
+        upstream:
+          global:
+            imageRegistry: ""
+          image:
+            registry: public.ecr.aws
+            repository: docker/library/redis
+          metrics:
+            image:
+              registry: ghcr.io
+              repository: oliver006/redis_exporter
+            command:
+              - /redis_exporter
+
+monitoring:
+  enabled: false
+
+# Kiali remains with foundation in the first split because it is tightly tied to
+# mesh topology and ingress behavior.
+kiali:
+  enabled: true
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              namespace: kiali
+              name: kiali-kiali-kiali-operator
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: kiali-kiali-kiali-operator
+              spec:
+                template:
+                  spec:
+                    automountServiceAccountToken: true
+  values:
+    routes:
+      inbound:
+        kiali:
+          hosts:
+            - kiali-on-prem.zavestudios.com
+    waitJob:
+      enabled: false
+    upstream:
+      allowAdHocKialiImage: true
+      image:
+        repo: quay.io/kiali/kiali-operator
+      cr:
+        spec:
+          deployment:
+            image_name: quay.io/kiali/kiali
+
+grafana:
+  enabled: false
+
+tempo:
+  enabled: false
+
+alloy:
+  enabled: false
+
+loki:
+  enabled: false

--- a/bigbang/observability/helmrelease.yaml
+++ b/bigbang/observability/helmrelease.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bigbang-observability
+  namespace: bigbang
+spec:
+  interval: 10m
+  driftDetection:
+    mode: enabled
+  chart:
+    spec:
+      chart: ./chart
+      sourceRef:
+        kind: GitRepository
+        name: bigbang
+        namespace: bigbang
+      interval: 10m
+  timeout: 20m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: bigbang-observability-values
+      valuesKey: values.yaml

--- a/bigbang/observability/kustomization.yaml
+++ b/bigbang/observability/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+
+configurations:
+  - kustomizeconfig.yaml
+
+configMapGenerator:
+  - name: bigbang-observability-values
+    namespace: bigbang
+    files:
+      - values.yaml=values-observability.yaml

--- a/bigbang/observability/kustomizeconfig.yaml
+++ b/bigbang/observability/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+# Teach Kustomize to rewrite ConfigMap references in Flux HelmRelease CRDs
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/bigbang/observability/values-observability.yaml
+++ b/bigbang/observability/values-observability.yaml
@@ -1,0 +1,408 @@
+# Big Bang observability values for on-prem environment
+
+domain: zavestudios.com
+
+gatekeeper:
+  enabled: false
+
+bbctl:
+  enabled: false
+
+kyverno:
+  enabled: false
+
+kyvernoReporter:
+  enabled: false
+
+kyvernoPolicies:
+  enabled: false
+
+eckOperator:
+  enabled: false
+
+elasticsearchKibana:
+  enabled: false
+
+fluentbit:
+  enabled: false
+
+neuvector:
+  enabled: false
+
+twistlock:
+  enabled: false
+
+istioCRDs:
+  enabled: false
+
+istiod:
+  enabled: false
+
+istioGateway:
+  enabled: false
+
+addons:
+  gitlab:
+    enabled: false
+  gitlabRunner:
+    enabled: false
+  externalSecrets:
+    enabled: false
+  vault:
+    enabled: false
+  keycloak:
+    enabled: false
+  argocd:
+    enabled: false
+
+monitoring:
+  enabled: true
+  values:
+    istio:
+      prometheus:
+        hosts:
+          - prometheus-on-prem.zavestudios.com
+      alertmanager:
+        hosts:
+          - alertmanager-on-prem.zavestudios.com
+    upstream:
+      global:
+        imageRegistry: ""
+      prometheusOperator:
+        serviceAccount:
+          automountServiceAccountToken: false
+        image:
+          registry: quay.io
+          repository: prometheus-operator/prometheus-operator
+        prometheusConfigReloader:
+          image:
+            registry: quay.io
+            repository: prometheus-operator/prometheus-config-reloader
+        admissionWebhooks:
+          enabled: true
+          patch:
+            image:
+              registry: registry.k8s.io
+              repository: ingress-nginx/kube-webhook-certgen
+              tag: v1.6.5
+              pullPolicy: IfNotPresent
+      prometheus:
+        prometheusSpec:
+          image:
+            registry: quay.io
+            repository: prometheus/prometheus
+          serviceAccountName: prometheus-monitoring-monitoring-kube-prometheus
+          automountServiceAccountToken: true
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: 200m
+            limits:
+              memory: 2Gi
+              cpu: 1000m
+          retention: 12h
+      alertmanager:
+        alertmanagerSpec:
+          image:
+            registry: quay.io
+            repository: prometheus/alertmanager
+      prometheus-node-exporter:
+        image:
+          registry: quay.io
+          repository: prometheus/node-exporter
+      kube-state-metrics:
+        automountServiceAccountToken: true
+        image:
+          registry: registry.k8s.io
+          repository: kube-state-metrics/kube-state-metrics
+      grafana:
+        automountServiceAccountToken: false
+        image:
+          registry: docker.io
+          repository: grafana/grafana
+        sidecar:
+          image:
+            registry: quay.io
+            repository: kiwigrid/k8s-sidecar
+
+kiali:
+  enabled: false
+
+grafana:
+  enabled: true
+  values:
+    global:
+      imageRegistry: ""
+    istio:
+      grafana:
+        hosts:
+          - grafana-on-prem.zavestudios.com
+    upstream:
+      image:
+        registry: docker.io
+        repository: grafana/grafana
+        tag: "12.3.1"
+      sidecar:
+        image:
+          registry: quay.io
+          repository: kiwigrid/k8s-sidecar
+          tag: "2.2.3"
+      initChownData:
+        enabled: false
+      grafana.ini:
+        server:
+          root_url: https://grafana-on-prem.zavestudios.com
+
+tempo:
+  enabled: true
+  values:
+    waitJob:
+      enabled: false
+    upstream:
+      tempo:
+        registry: docker.io
+        repository: grafana/tempo
+
+alloy:
+  enabled: true
+  flux:
+    install:
+      disableHooks: true
+    upgrade:
+      disableHooks: true
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              namespace: alloy
+              name: alloy-alloy-operator
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: alloy-alloy-operator
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      app.kubernetes.io/version: "1.5.2"
+                  spec:
+                    automountServiceAccountToken: true
+          - target:
+              group: apps
+              version: v1
+              kind: DaemonSet
+              namespace: alloy
+              name: alloy-alloy-logs
+            patch: |
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: alloy-alloy-logs
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      app.kubernetes.io/version: "v1.12.2"
+          - target:
+              group: batch
+              version: v1
+              kind: Job
+              namespace: alloy
+              name: alloy-upstream-add-finalizer
+            patch: |
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: alloy-upstream-add-finalizer
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      app.kubernetes.io/version: "0.1.2"
+                      sidecar.istio.io/inject: "true"
+                    annotations:
+                      sidecar.istio.io/inject: "true"
+                  spec:
+                    automountServiceAccountToken: false
+                    imagePullSecrets: []
+                    volumes:
+                      - name: k8s-api-access
+                        projected:
+                          defaultMode: 420
+                          sources:
+                            - serviceAccountToken:
+                                audience: https://kubernetes.default.svc
+                                expirationSeconds: 3600
+                                path: token
+                            - configMap:
+                                items:
+                                  - key: ca.crt
+                                    path: ca.crt
+                                name: kube-root-ca.crt
+                            - downwardAPI:
+                                items:
+                                  - fieldRef:
+                                      apiVersion: v1
+                                      fieldPath: metadata.namespace
+                                    path: namespace
+                    containers:
+                      - name: add-finalizers
+                        image: ghcr.io/grafana/helm-chart-toolbox-kubectl:0.1.2
+                        volumeMounts:
+                          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                            name: k8s-api-access
+                            readOnly: true
+                    serviceAccountName: alloy-upstream-add-finalizer
+          - target:
+              group: v1
+              version: v1
+              kind: ServiceAccount
+              namespace: alloy
+              name: alloy-upstream-add-finalizer
+            patch: |
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: alloy-upstream-add-finalizer
+                labels:
+                  app.kubernetes.io/version: "0.1.2"
+              automountServiceAccountToken: false
+  values:
+    alloy-operator:
+      waitForAlloyRemoval:
+        image:
+          registry: ghcr.io
+          repository: grafana/helm-chart-toolbox-kubectl
+          tag: "0.1.2"
+        podAnnotations:
+          sidecar.istio.io/inject: "true"
+        podLabels:
+          sidecar.istio.io/inject: "true"
+    applicationObservability:
+      enabled: true
+      collector: alloy-receiver
+      receivers:
+        otlp:
+          grpc:
+            enabled: true
+            port: 4317
+          http:
+            enabled: true
+            port: 4318
+    global:
+      imageRegistry: ""
+      imagePullSecrets: []
+      image:
+        registry: ""
+        pullSecrets: []
+    collectors:
+      alloy-receiver:
+        presets:
+          - deployment
+    k8s-monitoring:
+      alloy-logs:
+        image:
+          registry: docker.io
+          repository: grafana/alloy
+          tag: "v1.12.2"
+        configReloader:
+          image:
+            registry: quay.io
+            repository: prometheus-operator/prometheus-config-reloader
+            tag: "v0.77.2"
+      alloy-operator:
+        waitForAlloyRemoval:
+          image:
+            registry: ghcr.io
+            repository: grafana/helm-chart-toolbox-kubectl
+            tag: "0.1.2"
+        image:
+          registry: ghcr.io
+          repository: grafana/alloy-operator
+          tag: "1.5.2"
+        configReloader:
+          image:
+            registry: quay.io
+            repository: prometheus-operator/prometheus-config-reloader
+            tag: "v0.77.2"
+      alloy-metrics:
+        image:
+          registry: docker.io
+          repository: grafana/alloy
+          tag: "v1.12.2"
+        configReloader:
+          image:
+            registry: quay.io
+            repository: prometheus-operator/prometheus-config-reloader
+            tag: "v0.77.2"
+      alloy-receiver:
+        image:
+          registry: docker.io
+          repository: grafana/alloy
+          tag: "v1.12.2"
+        configReloader:
+          image:
+            registry: quay.io
+            repository: prometheus-operator/prometheus-config-reloader
+            tag: "v0.77.2"
+      integrations:
+        alloy:
+          image:
+            registry: docker.io
+            repository: grafana/alloy
+            tag: "v1.12.2"
+    upstream:
+      alloy-operator:
+        waitForAlloyRemoval:
+          image:
+            registry: ghcr.io
+            repository: grafana/helm-chart-toolbox-kubectl
+            tag: "0.1.2"
+        image:
+          registry: ghcr.io
+          repository: grafana/alloy-operator
+          tag: "1.5.2"
+        configReloader:
+          image:
+            registry: quay.io
+            repository: prometheus-operator/prometheus-config-reloader
+            tag: "v0.77.2"
+      alloy-logs:
+        image:
+          registry: docker.io
+          repository: grafana/alloy
+          tag: "v1.12.2"
+        configReloader:
+          image:
+            registry: quay.io
+            repository: prometheus-operator/prometheus-config-reloader
+            tag: "v0.77.2"
+      destinations:
+        - name: loki
+          type: loki
+          url: http://logging-loki.logging.svc.cluster.local:3100/loki/api/v1/push
+        - name: tempo
+          type: otlp
+          protocol: grpc
+          url: tempo-tempo.tempo.svc.cluster.local:4317
+          traces:
+            enabled: true
+
+loki:
+  enabled: true
+  values:
+    routes:
+      inbound:
+        loki:
+          enabled: true
+          hosts:
+            - loki-on-prem.zavestudios.com
+    loki:
+      image:
+        registry: docker.io
+        repository: grafana/loki
+        tag: "3.5.7"

--- a/bigbang/policy/helmrelease.yaml
+++ b/bigbang/policy/helmrelease.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bigbang-policy
+  namespace: bigbang
+spec:
+  interval: 10m
+  driftDetection:
+    mode: enabled
+  chart:
+    spec:
+      chart: ./chart
+      sourceRef:
+        kind: GitRepository
+        name: bigbang
+        namespace: bigbang
+      interval: 10m
+  timeout: 20m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: bigbang-policy-values
+      valuesKey: values.yaml

--- a/bigbang/policy/kustomization.yaml
+++ b/bigbang/policy/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+
+configurations:
+  - kustomizeconfig.yaml
+
+configMapGenerator:
+  - name: bigbang-policy-values
+    namespace: bigbang
+    files:
+      - values.yaml=values-policy.yaml

--- a/bigbang/policy/kustomizeconfig.yaml
+++ b/bigbang/policy/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+# Teach Kustomize to rewrite ConfigMap references in Flux HelmRelease CRDs
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/bigbang/policy/values-policy.yaml
+++ b/bigbang/policy/values-policy.yaml
@@ -1,0 +1,256 @@
+# Big Bang policy values for on-prem environment
+
+domain: zavestudios.com
+
+gatekeeper:
+  enabled: false
+
+bbctl:
+  enabled: false
+
+kyverno:
+  enabled: true
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              namespace: kyverno
+              name: kyverno-background-controller
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: kyverno-background-controller
+              spec:
+                template:
+                  spec:
+                    automountServiceAccountToken: false
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              namespace: kyverno
+              name: kyverno-cleanup-controller
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: kyverno-cleanup-controller
+              spec:
+                template:
+                  spec:
+                    automountServiceAccountToken: false
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              namespace: kyverno
+              name: kyverno-reports-controller
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: kyverno-reports-controller
+              spec:
+                template:
+                  spec:
+                    automountServiceAccountToken: false
+  flux:
+    install:
+      replace: true
+  values:
+    global:
+      image:
+        registry: ""
+    upstream:
+      admissionController:
+        container:
+          image:
+            defaultRegistry: ghcr.io
+            repository: kyverno/kyverno
+            tag: v1.16.3
+        initContainer:
+          image:
+            defaultRegistry: ghcr.io
+            repository: kyverno/kyvernopre
+            tag: v1.16.3
+      backgroundController:
+        image:
+          defaultRegistry: ghcr.io
+          repository: kyverno/background-controller
+          tag: v1.16.3
+      cleanupController:
+        image:
+          defaultRegistry: ghcr.io
+          repository: kyverno/cleanup-controller
+          tag: v1.16.3
+      reportsController:
+        image:
+          defaultRegistry: ghcr.io
+          repository: kyverno/reports-controller
+          tag: v1.16.3
+      crds:
+        migration:
+          image:
+            defaultRegistry: ghcr.io
+            repository: kyverno/kyverno-cli
+            tag: v1.16.3
+      webhooksCleanup:
+        image:
+          registry: registry.k8s.io
+          repository: kubectl
+          tag: v1.34.3
+
+kyvernoReporter:
+  enabled: true
+  values:
+    istio:
+      kyvernoReporter:
+        hosts:
+          - policyreporter-on-prem.zavestudios.com
+    upstream:
+      image:
+        registry: ghcr.io
+        repository: kyverno/policy-reporter
+        tag: "3.7.2"
+      ui:
+        enabled: true
+        image:
+          registry: ghcr.io
+          repository: kyverno/policy-reporter-ui
+          tag: "2.5.1"
+      plugin:
+        kyverno:
+          enabled: true
+          image:
+            registry: ghcr.io
+            repository: kyverno/policy-reporter/kyverno-plugin
+            tag: "0.5.3"
+
+kyvernoPolicies:
+  enabled: true
+  values:
+    waitJob:
+      enabled: false
+    bbtests:
+      enabled: false
+      scripts:
+        image: registry.k8s.io/kubectl:v1.34.3
+    policies:
+      update-automountserviceaccounttokens:
+        enabled: false
+      update-automountserviceaccounttokens-default:
+        enabled: false
+      restrict-image-registries:
+        parameters:
+          allow:
+            - registry1.dso.mil/
+            - ghcr.io/
+            - quay.io/
+            - docker.io/
+            - index.docker.io/
+            - registry.k8s.io/
+            - public.ecr.aws/
+        exclude:
+          any:
+            - resources:
+                namespaces:
+                  - alloy
+                names:
+                  - alloy-upstream-add-finalizer*
+      disallow-auto-mount-service-account-token:
+        exclude:
+          any:
+            - resources:
+                namespaces:
+                  - alloy
+                names:
+                  - alloy-upstream-add-finalizer*
+            - resources:
+                namespaces:
+                  - alloy
+                kinds:
+                  - Deployment
+                names:
+                  - alloy-alloy-operator
+                  - alloy-receiver
+            - resources:
+                namespaces:
+                  - kiali
+                kinds:
+                  - Deployment
+                names:
+                  - kiali-kiali-kiali-operator
+            - resources:
+                namespaces:
+                  - monitoring
+                kinds:
+                  - Deployment
+                names:
+                  - monitoring-monitoring-kube-state-metrics
+            - resources:
+                namespaces:
+                  - alloy
+                kinds:
+                  - ServiceAccount
+                names:
+                  - alloy-upstream-add-finalizer
+
+eckOperator:
+  enabled: false
+
+elasticsearchKibana:
+  enabled: false
+
+fluentbit:
+  enabled: false
+
+neuvector:
+  enabled: false
+
+twistlock:
+  enabled: false
+
+istioCRDs:
+  enabled: false
+
+istiod:
+  enabled: false
+
+istioGateway:
+  enabled: false
+
+addons:
+  gitlab:
+    enabled: false
+  gitlabRunner:
+    enabled: false
+  externalSecrets:
+    enabled: false
+  vault:
+    enabled: false
+  keycloak:
+    enabled: false
+  argocd:
+    enabled: false
+
+monitoring:
+  enabled: false
+
+kiali:
+  enabled: false
+
+grafana:
+  enabled: false
+
+tempo:
+  enabled: false
+
+alloy:
+  enabled: false
+
+loki:
+  enabled: false

--- a/bigbang/source/gitrepository.yaml
+++ b/bigbang/source/gitrepository.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: bigbang
+  namespace: bigbang
+spec:
+  interval: 1m
+  url: https://repo1.dso.mil/big-bang/bigbang.git
+  ref:
+    tag: 3.17.0  # Pin to specific version for reproducibility - currently supported version

--- a/bigbang/source/kustomization.yaml
+++ b/bigbang/source/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - gitrepository.yaml

--- a/bigbang/source/namespace.yaml
+++ b/bigbang/source/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bigbang

--- a/clusters/on-prem/bigbang-foundation-kustomization.yaml
+++ b/clusters/on-prem/bigbang-foundation-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: on-prem-bigbang-foundation
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: on-prem-platform-core
+    - name: on-prem-keycloak-secrets
+    - name: on-prem-bigbang-source
+  interval: 10m
+  path: ./bigbang/foundation
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  timeout: 20m

--- a/clusters/on-prem/bigbang-observability-kustomization.yaml
+++ b/clusters/on-prem/bigbang-observability-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: on-prem-bigbang-observability
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: on-prem-bigbang-source
+    - name: on-prem-bigbang-foundation
+  interval: 10m
+  path: ./bigbang/observability
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/clusters/on-prem/bigbang-policy-kustomization.yaml
+++ b/clusters/on-prem/bigbang-policy-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: on-prem-bigbang-policy
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: on-prem-bigbang-source
+    - name: on-prem-bigbang-foundation
+  interval: 10m
+  path: ./bigbang/policy
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/clusters/on-prem/bigbang-source-kustomization.yaml
+++ b/clusters/on-prem/bigbang-source-kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: on-prem-bigbang-source
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./bigbang/source
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system


### PR DESCRIPTION
## Summary
- add inactive split manifests for Big Bang source, foundation, policy, and observability
- add inactive top-level Flux kustomizations for the new Big Bang units
- keep the live `clusters/on-prem` entrypoint and monolithic Big Bang release unchanged

## Testing
- parsed all new YAML files locally with `python3`
- confirmed `clusters/on-prem/kustomization.yaml` remains unchanged and does not reference the new Flux files
- not run: local Kustomize render (`kustomize` is not installed in this environment)

## Notes
- `kiali` stays with foundation in this first cut because it is tightly coupled to mesh topology and ingress behavior

## Related
- closes no issue
- informs #240