### PR TITLE
Activate bigbang source kustomization

### DIFF
--- a/clusters/on-prem/kustomization.yaml
+++ b/clusters/on-prem/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - platform-core-kustomization.yaml
   - keycloak-secrets-kustomization.yaml
+  - bigbang-source-kustomization.yaml
   - bigbang-kustomization.yaml
   - platform-runtime-kustomization.yaml
   - platform-services-kustomization.yaml


### PR DESCRIPTION
## Summary
- activate the new `on-prem-bigbang-source` top-level Flux kustomization
- keep the monolithic `on-prem-bigbang` release path unchanged
- leave foundation, policy, and observability split units inactive

## Testing
- parsed `clusters/on-prem/kustomization.yaml` locally with `python3`
- confirmed the change is limited to one new top-level resource reference
- ran `kustomize build bigbang/source`
- ran `kustomize build bigbang/foundation`
- ran `kustomize build bigbang/policy`
- ran `kustomize build bigbang/observability`
- rendered `clusters/on-prem` locally with `kustomize build clusters/on-prem`

## Related
- closes no issue
- informs #240