### PR TITLE
Cut over Big Bang foundation packages

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -222,10 +222,10 @@ twistlock:
 
 # Istio - enabled with public images via values overrides
 istioCRDs:
-  enabled: true
+  enabled: false  # Moved to bigbang-foundation release
 
 istiod:
-  enabled: true
+  enabled: false  # Moved to bigbang-foundation release
   postRenderers:
     - kustomize:
         patches:
@@ -260,7 +260,7 @@ istiod:
           memory: 512Mi
 
 istioGateway:
-  enabled: true
+  enabled: false  # Moved to bigbang-foundation release
   postRenderers:
     - kustomize:
         patches:
@@ -307,7 +307,7 @@ addons:
     enabled: false
 
   externalSecrets:
-    enabled: true
+    enabled: false  # Moved to bigbang-foundation release
     postRenderers:
       - kustomize:
           patches:
@@ -348,7 +348,7 @@ addons:
           imagePullSecrets: []
 
   vault:
-    enabled: true
+    enabled: false  # Moved to bigbang-foundation release
     postRenderers:
       - kustomize:
           patches:
@@ -463,7 +463,7 @@ addons:
             app.kubernetes.io/version: "1.7.0"
 
   keycloak:
-    enabled: true
+    enabled: false  # Moved to bigbang-foundation release
     hostname: sso-on-prem  # Overrides default 'keycloak' prefix → sso-on-prem.zavestudios.com
     ingress:
       gateway: "public"
@@ -560,7 +560,7 @@ addons:
                         - name: private-registry
 
   argocd:
-    enabled: true
+    enabled: false  # Moved to bigbang-foundation release
     postRenderers:
       - kustomize:
           patches:
@@ -698,7 +698,7 @@ monitoring:
 
 # Kiali - service mesh observability
 kiali:
-  enabled: true
+  enabled: false  # Moved to bigbang-foundation release
   postRenderers:
     - kustomize:
         patches:

--- a/clusters/on-prem/kustomization.yaml
+++ b/clusters/on-prem/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - platform-core-kustomization.yaml
   - keycloak-secrets-kustomization.yaml
   - bigbang-source-kustomization.yaml
+  - bigbang-foundation-kustomization.yaml
   - bigbang-kustomization.yaml
   - platform-runtime-kustomization.yaml
   - platform-services-kustomization.yaml


### PR DESCRIPTION
## Summary
- activate the new `on-prem-bigbang-foundation` top-level Flux kustomization
- disable foundation-owned package families in the monolithic `bigbang/values.yaml`
- transfer foundation ownership instead of leaving it overlapped between old and new release units

## Testing
- ran `kustomize build bigbang`
- ran `kustomize build bigbang/foundation`
- ran `kustomize build clusters/on-prem`

## Notes
- `kiali` stays with foundation in this first cut because it is tightly coupled to mesh topology and ingress behavior
- this PR intentionally leaves policy and observability under the monolith for now

## Related
- closes no issue
- informs #240