### PR TITLE
Cut over Big Bang policy and observability

### DIFF
--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -15,7 +15,7 @@ bbctl:
   enabled: false
 
 kyverno:
-  enabled: true
+  enabled: false  # Moved to bigbang-policy release
   postRenderers:
     - kustomize:
         patches:
@@ -111,7 +111,7 @@ kyverno:
           tag: v1.34.3
 
 kyvernoReporter:
-  enabled: true
+  enabled: false  # Moved to bigbang-policy release
   values:
     istio:
       kyvernoReporter:
@@ -137,7 +137,7 @@ kyvernoReporter:
             tag: "0.5.3"
 
 kyvernoPolicies:
-  enabled: true
+  enabled: false  # Moved to bigbang-policy release
   values:
     waitJob:
       enabled: false  # Disable wait job - gluon uses hardcoded Iron Bank kubectl image
@@ -626,7 +626,7 @@ addons:
 
 # Monitoring stack with public images via values overrides
 monitoring:
-  enabled: true
+  enabled: false  # Moved to bigbang-observability release
   values:
     istio:
       prometheus:
@@ -736,7 +736,7 @@ kiali:
 
 # Standalone Grafana
 grafana:
-  enabled: true
+  enabled: false  # Moved to bigbang-observability release
   values:
     global:
       imageRegistry: ""  # Disable registry prepending
@@ -762,7 +762,7 @@ grafana:
 
 # Tempo - distributed tracing
 tempo:
-  enabled: true
+  enabled: false  # Moved to bigbang-observability release
   values:
     waitJob:
       enabled: false  # Disable wait job - gluon uses hardcoded Iron Bank kubectl image
@@ -773,7 +773,7 @@ tempo:
 
 # Alloy - unified observability collector
 alloy:
-  enabled: true
+  enabled: false  # Moved to bigbang-observability release
   flux:
     install:
       disableHooks: true
@@ -1003,7 +1003,7 @@ alloy:
 
 # Loki - log aggregation storage
 loki:
-  enabled: true
+  enabled: false  # Moved to bigbang-observability release
   values:
     routes:
       inbound:

--- a/clusters/on-prem/bigbang-observability-kustomization.yaml
+++ b/clusters/on-prem/bigbang-observability-kustomization.yaml
@@ -13,3 +13,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  wait: true
+  timeout: 20m

--- a/clusters/on-prem/bigbang-policy-kustomization.yaml
+++ b/clusters/on-prem/bigbang-policy-kustomization.yaml
@@ -13,3 +13,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  wait: true
+  timeout: 20m

--- a/clusters/on-prem/kustomization.yaml
+++ b/clusters/on-prem/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - keycloak-secrets-kustomization.yaml
   - bigbang-source-kustomization.yaml
   - bigbang-foundation-kustomization.yaml
+  - bigbang-policy-kustomization.yaml
+  - bigbang-observability-kustomization.yaml
   - bigbang-kustomization.yaml
   - platform-runtime-kustomization.yaml
   - platform-services-kustomization.yaml

--- a/clusters/on-prem/platform-runtime-kustomization.yaml
+++ b/clusters/on-prem/platform-runtime-kustomization.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
-    - name: on-prem-bigbang
+    - name: on-prem-bigbang-foundation
+    - name: on-prem-bigbang-policy
+    - name: on-prem-bigbang-observability
   interval: 10m
   path: ./platform/runtime
   prune: true


### PR DESCRIPTION
## Summary
- activate the new `on-prem-bigbang-policy` and `on-prem-bigbang-observability` top-level Flux kustomizations
- disable policy and observability families in the monolithic `bigbang/values.yaml`
- repoint `on-prem-platform-runtime` to the new Big Bang family units instead of the monolith

## Testing
- ran `kustomize build bigbang`
- ran `kustomize build bigbang/policy`
- ran `kustomize build bigbang/observability`
- ran `kustomize build clusters/on-prem`

## Notes
- this PR intentionally does not retire the monolithic `on-prem-bigbang` yet
- policy and observability top-level units now use `wait: true` because runtime depends on them

## Related
- closes no issue
- informs #240