### PR TITLE
Remove kyverno ghcr secret from runtime

### DIFF
--- a/platform/policies/kyverno/kustomization.yaml
+++ b/platform/policies/kyverno/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ghcr-secret.external-secret.yaml
   - require-signed-ghcr-images.yaml
   - inject-required-labels.yaml


### PR DESCRIPTION
## Summary
- remove the `kyverno/ghcr-secret` `ExternalSecret` from the runtime bundle
- keep the Kyverno cluster policies in place
- align `platform-runtime` with the live split state where no `kyverno` namespace currently exists

## Testing
- ran `kustomize build platform/runtime`
- ran `kustomize build clusters/on-prem`
- confirmed the rendered runtime output no longer includes an `ExternalSecret` in namespace `kyverno`

## Related
- closes no issue
- informs #240