### PR TITLE
Fix Kiali ServiceAccount automount for foundation release

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -451,6 +451,8 @@ kiali:
                   spec:
                     automountServiceAccountToken: true
   values:
+    serviceAccount:
+      automountServiceAccountToken: false
     routes:
       inbound:
         kiali:


### PR DESCRIPTION
## Summary
- set the Kiali chart ServiceAccount automount to `false` in the foundation values
- keep the Kiali operator pod template automount explicitly `true` so the policy exemption remains narrow
- addresses the live Kyverno policy violation preventing the Kiali operator from starting cleanly

## Testing
- `kustomize build bigbang/foundation`

## Related
- closes the remaining repo-side part of `gitops#262`