### PR TITLE
Force replace platform services on immutable drift

### DIFF
--- a/clusters/on-prem/platform-services-kustomization.yaml
+++ b/clusters/on-prem/platform-services-kustomization.yaml
@@ -9,6 +9,7 @@ spec:
   interval: 2m
   path: ./platform/services
   prune: true
+  force: true
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Summary
- set the `on-prem-platform-services` Flux Kustomization to `force: true`
- allow Flux to replace immutable resources in the Airflow service path instead of failing the reconciliation when the bootstrap Job template drifts
- this addresses the current top-level blocker on `Job/platform/airflow-admin-password-set`

## Testing
- `kustomize build clusters/on-prem`

## Notes
- the current failure is a plain immutable `Job` apply error, not a graph dependency problem
- `platform/services` currently only owns Airflow, so the force scope is intentionally narrow