### PR TITLE
[codex] Add monitoring node-exporter Kyverno exception

### DIFF
--- a/bigbang/policy/values-policy.yaml
+++ b/bigbang/policy/values-policy.yaml
@@ -161,6 +161,16 @@ kyvernoPolicies:
                   - alloy
                 names:
                   - alloy-upstream-add-finalizer*
+      restrict-volume-types:
+        exclude:
+          any:
+            - resources:
+                namespaces:
+                  - monitoring
+                kinds:
+                  - DaemonSet
+                names:
+                  - monitoring-monitoring-prometheus-node-exporter
       disallow-auto-mount-service-account-token:
         exclude:
           any:

--- a/platform/policies/kyverno/enforce/bigbang/restrict-volume-types.yaml
+++ b/platform/policies/kyverno/enforce/bigbang/restrict-volume-types.yaml
@@ -36,6 +36,13 @@ spec:
       - resources:
           namespaces:
           - kube-system
+      - resources:
+          namespaces:
+          - monitoring
+          kinds:
+          - DaemonSet
+          names:
+          - monitoring-monitoring-prometheus-node-exporter
     match:
       all:
       - resources:


### PR DESCRIPTION
What changed
- Added a Kyverno exclusion for the monitoring node-exporter DaemonSet in the Big Bang policy values.
- Mirrored the same exclusion into the checked-in Kyverno policy snapshot.

Why
- The monitoring HelmRelease was blocked by the restrict-volume-types policy.
- The prometheus-node-exporter DaemonSet uses a volume type that the policy denies.
- The existing policy exceptions already covered Kiali and monitoring kube-state-metrics, but not node-exporter.

Impact
- Monitoring can proceed without weakening the policy for unrelated workloads.
- The exception is limited to the monitoring namespace and the node-exporter DaemonSet only.

Validation
- git diff --check
