### PR TITLE
[codex] Harden foundation app pods for Kyverno

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -138,6 +138,14 @@ addons:
                     metadata:
                       labels:
                         app.kubernetes.io/version: "1.2.1"
+                    spec:
+                      automountServiceAccountToken: false
+                      securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 65532
+                        runAsGroup: 65532
+                        seccompProfile:
+                          type: RuntimeDefault
     values:
       waitJob: false
       upstream:
@@ -380,6 +388,12 @@ addons:
                   template:
                     spec:
                       automountServiceAccountToken: false
+                      securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 999
+                        runAsGroup: 999
+                        seccompProfile:
+                          type: RuntimeDefault
             - target:
                 group: apps
                 version: v1
@@ -395,6 +409,12 @@ addons:
                   template:
                     spec:
                       automountServiceAccountToken: false
+                      securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 999
+                        runAsGroup: 999
+                        seccompProfile:
+                          type: RuntimeDefault
     values:
       istio:
         argocd:


### PR DESCRIPTION
What changed
- Added non-root pod securityContext settings to the foundation-owned `external-secrets` Deployment.
- Added non-root pod securityContext settings to the foundation-owned `argocd` Deployment and StatefulSet templates.

Why
- Kyverno is enforcing `require-non-root-user`, `require-non-root-group`, and `restrict-capabilities` on these workloads.
- The live install loops were failing before pods could start because the rendered pod specs were still treated as root-default workloads.

Impact
- `external-secrets` and `argocd` should now satisfy the admission policies without broadening the policy set.
- The change is limited to the foundation release values for these two workloads.

Validation
- `git diff --check`
- `kustomize build bigbang/foundation`

Follow-up
- `keycloak` is still separate. Its current blocker is image verification/digest pinning for `ghcr.io/zavestudios/keycloak:bootstrap`, and I did not guess at that digest in this PR.
