### PR TITLE
[codex] Pin Keycloak bootstrap image by digest

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -351,6 +351,9 @@ addons:
                       automountServiceAccountToken: false
                       imagePullSecrets:
                         - name: private-registry
+                      containers:
+                        - name: keycloak
+                          image: ghcr.io/zavestudios/keycloak@sha256:ae0cfe0050552e2341cdb0c14d03614dba3d6719c6ecc603ef62050233417c17
             - target:
                 group: apps
                 version: v1


### PR DESCRIPTION
What changed
- Pinned the Keycloak StatefulSet pod image to the promoted immutable digest for `ghcr.io/zavestudios/keycloak`.
- Left the chart tag input alone, but overrode the rendered pod image so the live workload uses the verified digest.

Why
- Kyverno was blocking `keycloak` because the live pod spec still referenced the mutable `bootstrap` tag.
- The promotion workflow already published the digest that `bootstrap` is supposed to track.

Recovered digest
- `sha256:ae0cfe0050552e2341cdb0c14d03614dba3d6719c6ecc603ef62050233417c17`

Impact
- Keeps Keycloak on the expected promoted image while satisfying the signature/digest enforcement path.
- Scope stays limited to the foundation-owned Keycloak release.

Validation
- `git diff --check`
- `kustomize build bigbang/foundation`
