### PR TITLE
Fix external-secrets service account automount

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -123,6 +123,17 @@ addons:
       - kustomize:
           patches:
             - target:
+                version: v1
+                kind: ServiceAccount
+                namespace: external-secrets
+                name: external-secrets
+              patch: |
+                apiVersion: v1
+                kind: ServiceAccount
+                metadata:
+                  name: external-secrets
+                automountServiceAccountToken: false
+            - target:
                 group: apps
                 version: v1
                 kind: Deployment
@@ -149,6 +160,8 @@ addons:
     values:
       waitJob: false
       upstream:
+        serviceAccount:
+          automountServiceAccountToken: false
         podLabels:
           vault-ingress: "true"
         image:

--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -312,6 +312,17 @@ addons:
       - kustomize:
           patches:
             - target:
+                version: v1
+                kind: ServiceAccount
+                namespace: external-secrets
+                name: external-secrets
+              patch: |
+                apiVersion: v1
+                kind: ServiceAccount
+                metadata:
+                  name: external-secrets
+                automountServiceAccountToken: false
+            - target:
                 group: apps
                 version: v1
                 kind: Deployment
@@ -330,6 +341,8 @@ addons:
     values:
       waitJob: false
       upstream:
+        serviceAccount:
+          automountServiceAccountToken: false
         podLabels:
           vault-ingress: "true"
         image:


### PR DESCRIPTION
Lane: ZaveStudios
Work type: repo-side remediation
Execution surface: bigbang foundation values
Expected outcome: make the rendered external-secrets ServiceAccount satisfy Kyverno by explicitly disabling token automount at the ServiceAccount layer.

## Summary
- add a post-render patch for `ServiceAccount/external-secrets`
- set `upstream.serviceAccount.automountServiceAccountToken: false`
- mirror the same change into the disabled monolithic `bigbang/values.yaml` copy to keep split-source parity

## Why
Live cluster evidence showed:
- `external-secrets` was still denied by Kyverno
- the rendered Deployment already had `automountServiceAccountToken: false`
- the rendered `ServiceAccount` did not
- Kyverno was explicitly flagging `serviceaccount/external-secrets`

This PR fixes the concrete missing object instead of continuing to probe the same manifest path.

## Validation
- `kustomize build bigbang/foundation`
- `git diff --check`