### PR TITLE
Tighten argocd kyverno render patches

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -431,6 +431,220 @@ addons:
                         runAsGroup: 999
                         seccompProfile:
                           type: RuntimeDefault
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: argocd
+                name: argocd-argocd-applicationset-controller
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: argocd
+                name: argocd-argocd-server
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: argocd
+                name: argocd-argocd-repo-server
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: argocd
+                name: argocd-argocd-dex-server
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: argocd
+                name: argocd-argocd-notifications-controller
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: StatefulSet
+                namespace: argocd
+                name: argocd-argocd-application-controller
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: StatefulSet
+                namespace: argocd
+                name: redis-bb-master
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+                - op: add
+                  path: /spec/template/spec/containers/1/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: StatefulSet
+                namespace: argocd
+                name: redis-bb-replicas
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+                - op: add
+                  path: /spec/template/spec/containers/1/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
     values:
       istio:
         argocd:

--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -607,6 +607,220 @@ addons:
                   template:
                     spec:
                       automountServiceAccountToken: false
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: argocd
+                name: argocd-argocd-applicationset-controller
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: argocd
+                name: argocd-argocd-server
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: argocd
+                name: argocd-argocd-repo-server
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: argocd
+                name: argocd-argocd-dex-server
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: Deployment
+                namespace: argocd
+                name: argocd-argocd-notifications-controller
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: StatefulSet
+                namespace: argocd
+                name: argocd-argocd-application-controller
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: StatefulSet
+                namespace: argocd
+                name: redis-bb-master
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+                - op: add
+                  path: /spec/template/spec/containers/1/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+            - target:
+                group: apps
+                version: v1
+                kind: StatefulSet
+                namespace: argocd
+                name: redis-bb-replicas
+              patch: |
+                - op: add
+                  path: /spec/template/spec/automountServiceAccountToken
+                  value: false
+                - op: add
+                  path: /spec/template/spec/securityContext
+                  value:
+                    runAsNonRoot: true
+                    runAsUser: 999
+                    runAsGroup: 999
+                    seccompProfile:
+                      type: RuntimeDefault
+                - op: add
+                  path: /spec/template/spec/containers/0/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+                - op: add
+                  path: /spec/template/spec/containers/1/securityContext
+                  value:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
     values:
       istio:
         argocd:


### PR DESCRIPTION
Lane: ZaveStudios
Work type: repo-side remediation
Execution surface: bigbang foundation values
Expected outcome: make the ArgoCD child release render pod-level and container-level security settings explicitly enough to satisfy Kyverno across both ArgoCD core workloads and the bundled Redis subchart.

## Summary
- keep the broad argocd label-selector post-render patches
- add explicit per-resource JSON patches for the ArgoCD Deployments and StatefulSets
- add the same explicit patches for `redis-bb-master` and `redis-bb-replicas`
- mirror the same patch set into the disabled monolithic `bigbang/values.yaml` copy for split-source parity

## Why
Live cluster evidence after the stale Helm release cleanup showed:
- `argocd` was no longer blocked only by broken Helm storage
- fresh install attempts still failed pod admission on:
  - `argocd-argocd-application-controller`
  - `argocd-argocd-repo-server`
  - `argocd-argocd-server`
  - `argocd-argocd-dex-server`
  - `argocd-argocd-applicationset-controller`
  - `redis-bb-master`
  - `redis-bb-replicas`
- the current Kyverno deny set remained:
  - `require-non-root-group`
  - `require-non-root-user`
  - `restrict-capabilities`

The live `HelmRelease` already contained the broader label-selector post-render patch, but the release kept churning and the rendered install path still failed admission. This PR makes the patch path resource-specific so the Redis subchart and each named ArgoCD workload get the same explicit render treatment.

## Validation
- `kustomize build bigbang/foundation`
- `git diff --check`