### PR TITLE
Disable Istio injection for ArgoCD workloads

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -402,6 +402,9 @@ addons:
                   name: not-used
                 spec:
                   template:
+                    metadata:
+                      annotations:
+                        sidecar.istio.io/inject: "false"
                     spec:
                       automountServiceAccountToken: false
                       securityContext:
@@ -423,6 +426,9 @@ addons:
                   name: not-used
                 spec:
                   template:
+                    metadata:
+                      annotations:
+                        sidecar.istio.io/inject: "false"
                     spec:
                       automountServiceAccountToken: false
                       securityContext:

--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -590,8 +590,17 @@ addons:
                   name: not-used
                 spec:
                   template:
+                    metadata:
+                      annotations:
+                        sidecar.istio.io/inject: "false"
                     spec:
                       automountServiceAccountToken: false
+                      securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 999
+                        runAsGroup: 999
+                        seccompProfile:
+                          type: RuntimeDefault
             - target:
                 group: apps
                 version: v1
@@ -605,8 +614,17 @@ addons:
                   name: not-used
                 spec:
                   template:
+                    metadata:
+                      annotations:
+                        sidecar.istio.io/inject: "false"
                     spec:
                       automountServiceAccountToken: false
+                      securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 999
+                        runAsGroup: 999
+                        seccompProfile:
+                          type: RuntimeDefault
             - target:
                 group: apps
                 version: v1


### PR DESCRIPTION
## Summary
- disable Istio sidecar injection on ArgoCD Deployment and StatefulSet pod templates
- keep the foundation split and monolithic values files aligned
- leave the existing non-root and capability-drop security patches in place

## Why
Current cluster evidence shows the rendered ArgoCD manifests already contain the expected pod-level security context and container-level capability drops. The remaining admission failures are happening in an istio-injection=enabled namespace, so this change removes the mutation layer from ArgoCD workloads before Kyverno evaluates the final Pod spec.

## Validation
- kustomize build bigbang/foundation
- git diff --check
