### PR TITLE
Disable Istio injection for external-secrets

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -147,6 +147,8 @@ addons:
                 spec:
                   template:
                     metadata:
+                      annotations:
+                        sidecar.istio.io/inject: "false"
                       labels:
                         app.kubernetes.io/version: "1.2.1"
                     spec:

--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -336,6 +336,8 @@ addons:
                 spec:
                   template:
                     metadata:
+                      annotations:
+                        sidecar.istio.io/inject: "false"
                       labels:
                         app.kubernetes.io/version: "1.2.1"
     values:


### PR DESCRIPTION
## Summary
- disable Istio sidecar injection on the external-secrets Deployment template
- keep the foundation split and monolithic values files aligned

## Why
The external-secrets namespace is istio-injection enabled, and the live install is failing the same Kyverno non-root and capabilities checks that ArgoCD hit before the sidecar opt-out. This change removes the mutation layer from the controller pod template so Kyverno evaluates the intended rendered spec.

## Validation
- kustomize build bigbang/foundation
- git diff --check
