### PR TITLE
Backfill Mia OpenClaw gateway mode on startup

### DIFF
--- a/tenants/mia/deployment.yaml
+++ b/tenants/mia/deployment.yaml
@@ -75,6 +75,8 @@ spec:
           const cfg = JSON.parse(fs.readFileSync(path, 'utf8'));
 
           cfg.gateway = cfg.gateway || {};
+          // Backfill legacy PVC configs that predate the OpenClaw gateway.mode field.
+          cfg.gateway.mode = cfg.gateway.mode || 'local';
           cfg.gateway.auth = cfg.gateway.auth || {};
           cfg.gateway.auth.mode = 'token';
           cfg.gateway.auth.token = {


### PR DESCRIPTION
## Summary
- backfill `gateway.mode` in the `mia` startup config reconciler
- keep the existing PVC-backed OpenClaw state migration path intact
- preserve the deliberate OpenClaw upgrade while repairing legacy persisted configs on boot

## Why
The `mia` deployment already seeds and reconciles `/home/node/.openclaw/openclaw.json` from a PVC. Older PVC-backed configs can be missing `gateway.mode`, which causes the newer OpenClaw runtime to refuse startup on restart.

## Validation
- reviewed the current `tenants/mia/deployment.yaml` reconciler path
- added a minimal startup backfill for `gateway.mode` with no other behavior changes
