### PR TITLE
[codex] let external-secrets join Istio mesh

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -147,8 +147,6 @@ addons:
                 spec:
                   template:
                     metadata:
-                      annotations:
-                        sidecar.istio.io/inject: "false"
                       labels:
                         app.kubernetes.io/version: "1.2.1"
                     spec:

--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -336,8 +336,6 @@ addons:
                 spec:
                   template:
                     metadata:
-                      annotations:
-                        sidecar.istio.io/inject: "false"
                       labels:
                         app.kubernetes.io/version: "1.2.1"
                     spec:


### PR DESCRIPTION
## What changed
- Removed the explicit `sidecar.istio.io/inject: "false"` annotation from the `external-secrets` deployment patch in both Big Bang values files.

## Why
- `external-secrets` needs a meshed pod path to reach Vault reliably under STRICT mTLS.
- The previous opt-out kept the controller out of the mesh, which matched the observed `vault-kv` client-creation resets.

## Validation
- `git diff --check` on the touched files.
- Confirmed the change is limited to the two Big Bang values files.

## Impact
- The controller should receive an Istio sidecar on the next reconciliation and be able to build the Vault provider client again.
