### PR TITLE
[codex] remove platform-core wait gate

### DIFF
--- a/clusters/on-prem/platform-core-kustomization.yaml
+++ b/clusters/on-prem/platform-core-kustomization.yaml
@@ -10,4 +10,3 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  wait: true

--- a/docs/fluxcd-reconciliation-order.md
+++ b/docs/fluxcd-reconciliation-order.md
@@ -64,7 +64,7 @@ This is installed during cluster bootstrap with `flux bootstrap` and manages the
 **FluxCD Name:** `on-prem-platform-core`
 **Path:** `./platform/core`
 **Dependencies:** None (first application-layer kustomization)
-**Wait:** Yes
+**Wait:** No
 **Interval:** 10m
 
 **Owns:**
@@ -73,7 +73,9 @@ This is installed during cluster bootstrap with `flux bootstrap` and manages the
 - `platform/sealed-secrets/` - Sealed Secrets controller
 - `platform/cloudflare/` - Cloudflared tunnel (credentials from Vault)
 
-**Purpose:** Bootstrap essential infrastructure that other components depend on.
+**Purpose:** Bootstrap essential infrastructure that other components depend on
+without blocking the graph on child health. This prevents the cloudflared
+ExternalSecret from deadlocking the controller update path.
 
 ---
 

--- a/docs/top-level-reconciliation-inventory-2026-05.md
+++ b/docs/top-level-reconciliation-inventory-2026-05.md
@@ -45,7 +45,7 @@ Structural observations:
 
 | Kustomization | Path | Depends On | Interval | Timeout | `wait: true` | Current Scope | Blast Radius if Stalled |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `on-prem-platform-core` | `./platform/core` | none | `10m` | default | Yes | namespaces, default serviceaccounts, sealed-secrets, cloudflare | blocks both `keycloak-secrets` and `bigbang` |
+| `on-prem-platform-core` | `./platform/core` | none | `10m` | default | No | namespaces, default serviceaccounts, sealed-secrets, cloudflare | no longer blocks downstream units on child health; still supplies foundational manifests |
 | `on-prem-keycloak-secrets` | `./platform/keycloak` | `on-prem-platform-core` | `10m` | default | Yes | keycloak namespace, headless service, ExternalSecrets | blocks `bigbang` because Big Bang expects Keycloak secrets first |
 | `on-prem-bigbang` | `./bigbang` | `on-prem-platform-core`, `on-prem-keycloak-secrets` | `10m` | `20m` | Yes | Big Bang GitRepository, HelmRelease, generated values, shared platform stack | blocks all downstream runtime and services work |
 | `on-prem-platform-runtime` | `./platform/runtime` | `on-prem-bigbang` | `10m` | `20m` | Yes | Alloy receiver, Alloy hook support, Vault, Kyverno, ArgoCD platform resources | blocks `platform-services`; also delays shared runtime remediation outside Big Bang |

--- a/docs/wait-true-justification-2026-06.md
+++ b/docs/wait-true-justification-2026-06.md
@@ -31,7 +31,7 @@ This review covers the current top-level Flux `Kustomization` objects under:
 
 | Kustomization | Current `wait: true` | Classification | Reasoning | Proposed action |
 | --- | --- | --- | --- | --- |
-| `on-prem-platform-core` | Yes | Provisional | This unit is foundational, but the current scope is mostly namespaces, default serviceaccounts, sealed-secrets, and Cloudflare resources. The repo evidence does not yet show that downstream units require full health before they can safely apply. | Re-test whether `dependsOn` without `wait: true` preserves correct ordering for `keycloak-secrets` and `bigbang`. |
+| `on-prem-platform-core` | No | Resolved | Health gating here created a bootstrap deadlock: `platform-core` waited on `cloudflared-credentials`, which waited on `vault-kv`, which could not recover until the updated `external-secrets` controller came through `bigbang`. Apply ordering remains explicit via `dependsOn`; child health should not block the graph at this layer. | Keep `wait` disabled unless a specific downstream prerequisite proves it must be reintroduced. |
 | `on-prem-keycloak-secrets` | Yes | Provisional | The inline comment says Big Bang requires Keycloak secrets first, which suggests a real prerequisite. But the unit mostly manages namespace and `ExternalSecret` wiring, and the repo does not yet prove that Big Bang must wait for full health rather than existence of the secret-producing resources. | Define the exact contract: is Big Bang blocked on secret objects existing, external secret sync completing, or application-level Keycloak readiness? Keep gated until that is explicit. |
 | `on-prem-bigbang` | Yes | Required | This is a broad shared-platform tier centered on a `HelmRelease`, and the recent incident showed that downstream runtime and services behavior is materially coupled to whether this unit reaches a good state. Removing the gate before decomposition would trade a legible blocker for less predictable downstream failure. | Keep `wait: true` in place for now; make this the first structural split target. |
 | `on-prem-platform-runtime` | Yes | Remove candidate | This unit currently bundles Alloy receiver/hook support, Vault, Kyverno, and ArgoCD platform resources. That scope is too broad for one hard health gate, and the repo evidence does not show that all downstream services need the entire bundle healthy before they can apply. The current gate likely amplifies blast radius more than it protects correctness. | First preference: split the unit. Short of that, test whether the gate can be relaxed to apply ordering only. |
@@ -41,12 +41,14 @@ This review covers the current top-level Flux `Kustomization` objects under:
 
 1. `on-prem-bigbang` is the only current top-level unit whose `wait: true`
    setting is clearly justified by present evidence.
-2. `on-prem-platform-core` and `on-prem-keycloak-secrets` may have legitimate
-   prerequisites, but the contract is still too implicit.
-3. `on-prem-platform-runtime` is the strongest `wait: true` removal candidate in
+2. `on-prem-platform-core` no longer health-gates the graph; the bootstrap
+   deadlock it created is now removed.
+3. `on-prem-keycloak-secrets` may still have a legitimate prerequisite, but the
+   contract is still too implicit.
+4. `on-prem-platform-runtime` is the strongest `wait: true` removal candidate in
    the current graph, though splitting it is preferable to simply dropping the
    gate blindly.
-4. The current graph uses health gating as a default control-plane posture more
+5. The current graph uses health gating as a default control-plane posture more
    often than the repo evidence supports.
 
 ## Follow-Up Questions for `gitops#240`


### PR DESCRIPTION
## Summary
- Remove `wait: true` from `on-prem-platform-core` so Flux can advance the graph after apply ordering instead of waiting on `cloudflared-credentials` health.
- Update the GitOps reconciliation docs and wait-justification table to reflect the new graph behavior.

## Why
- `platform-core` was health-gating on `cloudflared-credentials`.
- `cloudflared-credentials` depended on `vault-kv`.
- `vault-kv` could not recover until the updated `external-secrets` controller came through `bigbang`.
- That created a bootstrap deadlock that prevented the fix from propagating.

## Validation
- `git diff --check`
- Verified the diff is limited to the platform-core Kustomization and its supporting reconciliation docs.

## Impact
- `on-prem-platform-core` will now report Ready after resources are applied, without waiting for child health.
- Downstream Flux units can proceed to reconcile the updated controller path needed to recover Vault-backed secrets.
