### PR TITLE
[codex] remove keycloak-secrets wait gate

### DIFF
--- a/clusters/on-prem/keycloak-secrets-kustomization.yaml
+++ b/clusters/on-prem/keycloak-secrets-kustomization.yaml
@@ -14,6 +14,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  wait: true
   dependsOn:
     - name: on-prem-platform-core  # Requires Vault and External Secrets Operator

--- a/docs/fluxcd-reconciliation-order.md
+++ b/docs/fluxcd-reconciliation-order.md
@@ -83,14 +83,16 @@ ExternalSecret from deadlocking the controller update path.
 **FluxCD Name:** `on-prem-keycloak-secrets`
 **Path:** `./platform/keycloak`
 **Dependencies:** `on-prem-platform-core`
-**Wait:** Yes
+**Wait:** No
 **Interval:** 10m
 
 **Owns:**
 - `platform/keycloak/namespace.yaml` - Keycloak namespace
 - `platform/keycloak/*.external-secret.yaml` - ExternalSecrets for Keycloak credentials
 
-**Purpose:** Ensure Keycloak secrets exist before BigBang deploys Keycloak. Depends on platform-core for Vault and External Secrets Operator.
+**Purpose:** Ensure Keycloak secret resources are applied before BigBang
+deploys Keycloak. Dependency ordering stays explicit via `dependsOn`, but
+child health does not block the graph here.
 
 ---
 
@@ -136,7 +138,7 @@ ExternalSecret from deadlocking the controller update path.
 ## Reconciliation Behavior
 
 ### Wait Semantics
-All kustomizations have `wait: true`, meaning FluxCD will:
+Health-gated kustomizations have `wait: true`, meaning FluxCD will:
 1. Apply all resources
 2. Wait for all resources to become Ready
 3. Only then mark the kustomization as Ready

--- a/docs/top-level-reconciliation-inventory-2026-05.md
+++ b/docs/top-level-reconciliation-inventory-2026-05.md
@@ -34,10 +34,11 @@ on-prem-platform-core
 
 Structural observations:
 
-- four of five top-level units use `wait: true`
+- three of five top-level units use `wait: true`
 - `on-prem-bigbang` is the central health gate for downstream runtime and
   services work
-- `on-prem-platform-services` is the only top-level unit without `wait: true`
+- `on-prem-platform-core`, `on-prem-keycloak-secrets`, and
+  `on-prem-platform-services` do not health-gate the graph
 - the graph currently optimizes for ordered convergence, but it does so by
   concentrating failure blast radius in `on-prem-bigbang`
 
@@ -46,7 +47,7 @@ Structural observations:
 | Kustomization | Path | Depends On | Interval | Timeout | `wait: true` | Current Scope | Blast Radius if Stalled |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `on-prem-platform-core` | `./platform/core` | none | `10m` | default | No | namespaces, default serviceaccounts, sealed-secrets, cloudflare | no longer blocks downstream units on child health; still supplies foundational manifests |
-| `on-prem-keycloak-secrets` | `./platform/keycloak` | `on-prem-platform-core` | `10m` | default | Yes | keycloak namespace, headless service, ExternalSecrets | blocks `bigbang` because Big Bang expects Keycloak secrets first |
+| `on-prem-keycloak-secrets` | `./platform/keycloak` | `on-prem-platform-core` | `10m` | default | No | keycloak namespace, headless service, ExternalSecrets | no longer blocks `bigbang` on child health; still preserves apply ordering |
 | `on-prem-bigbang` | `./bigbang` | `on-prem-platform-core`, `on-prem-keycloak-secrets` | `10m` | `20m` | Yes | Big Bang GitRepository, HelmRelease, generated values, shared platform stack | blocks all downstream runtime and services work |
 | `on-prem-platform-runtime` | `./platform/runtime` | `on-prem-bigbang` | `10m` | `20m` | Yes | Alloy receiver, Alloy hook support, Vault, Kyverno, ArgoCD platform resources | blocks `platform-services`; also delays shared runtime remediation outside Big Bang |
 | `on-prem-platform-services` | `./platform/services` | `on-prem-platform-runtime` | `2m` | `25m` | No | Airflow platform service | isolated leaf tier; currently blocked entirely by upstream runtime gate |
@@ -87,14 +88,14 @@ Assessment:
 - this is a narrow prerequisite unit
 - it exists only to ensure Keycloak-related secrets and service wiring are
   present before Big Bang
-- the scope is small enough that a stall here is legible, but it still blocks
-  `on-prem-bigbang`
+- health gating here was not needed for apply ordering and participated in the
+  same bootstrap deadlock as `on-prem-platform-core`
 
 Open question:
 
 - should this remain a separate unit, or should the dependency be modeled
-  differently so Keycloak secret readiness does not hold the entire Big Bang
-  tier hostage?
+  differently so Keycloak secret readiness is represented more explicitly than
+  a top-level health gate?
 
 ### `on-prem-bigbang`
 
@@ -189,8 +190,6 @@ Open question:
 Recommended first-pass targets for `gitops#240`:
 
 1. Audit whether `wait: true` is actually load-bearing for:
-   - `on-prem-platform-core`
-   - `on-prem-keycloak-secrets`
    - `on-prem-platform-runtime`
 
 2. Define the first `on-prem-bigbang` split proposal.

--- a/docs/wait-true-justification-2026-06.md
+++ b/docs/wait-true-justification-2026-06.md
@@ -32,7 +32,7 @@ This review covers the current top-level Flux `Kustomization` objects under:
 | Kustomization | Current `wait: true` | Classification | Reasoning | Proposed action |
 | --- | --- | --- | --- | --- |
 | `on-prem-platform-core` | No | Resolved | Health gating here created a bootstrap deadlock: `platform-core` waited on `cloudflared-credentials`, which waited on `vault-kv`, which could not recover until the updated `external-secrets` controller came through `bigbang`. Apply ordering remains explicit via `dependsOn`; child health should not block the graph at this layer. | Keep `wait` disabled unless a specific downstream prerequisite proves it must be reintroduced. |
-| `on-prem-keycloak-secrets` | Yes | Provisional | The inline comment says Big Bang requires Keycloak secrets first, which suggests a real prerequisite. But the unit mostly manages namespace and `ExternalSecret` wiring, and the repo does not yet prove that Big Bang must wait for full health rather than existence of the secret-producing resources. | Define the exact contract: is Big Bang blocked on secret objects existing, external secret sync completing, or application-level Keycloak readiness? Keep gated until that is explicit. |
+| `on-prem-keycloak-secrets` | No | Resolved | This unit was also health-gating on `ExternalSecret` readiness and therefore participated in the same bootstrap deadlock as `platform-core`. Big Bang only needs the secret-producing resources to exist in GitOps order; it should not wait for the current Vault/controller loop to fully settle here. | Keep `wait` disabled unless a concrete Keycloak readiness dependency is proven later. |
 | `on-prem-bigbang` | Yes | Required | This is a broad shared-platform tier centered on a `HelmRelease`, and the recent incident showed that downstream runtime and services behavior is materially coupled to whether this unit reaches a good state. Removing the gate before decomposition would trade a legible blocker for less predictable downstream failure. | Keep `wait: true` in place for now; make this the first structural split target. |
 | `on-prem-platform-runtime` | Yes | Remove candidate | This unit currently bundles Alloy receiver/hook support, Vault, Kyverno, and ArgoCD platform resources. That scope is too broad for one hard health gate, and the repo evidence does not show that all downstream services need the entire bundle healthy before they can apply. The current gate likely amplifies blast radius more than it protects correctness. | First preference: split the unit. Short of that, test whether the gate can be relaxed to apply ordering only. |
 | `on-prem-platform-services` | No | N/A | This leaf tier already avoids `wait: true` and is the healthiest pattern in the current graph. | Preserve this default unless a specific service family proves a real health-gating need. |
@@ -43,8 +43,8 @@ This review covers the current top-level Flux `Kustomization` objects under:
    setting is clearly justified by present evidence.
 2. `on-prem-platform-core` no longer health-gates the graph; the bootstrap
    deadlock it created is now removed.
-3. `on-prem-keycloak-secrets` may still have a legitimate prerequisite, but the
-   contract is still too implicit.
+3. `on-prem-keycloak-secrets` no longer health-gates the graph for the same
+   reason; apply ordering is enough at this layer.
 4. `on-prem-platform-runtime` is the strongest `wait: true` removal candidate in
    the current graph, though splitting it is preferable to simply dropping the
    gate blindly.
@@ -60,9 +60,7 @@ This review covers the current top-level Flux `Kustomization` objects under:
    - application readiness
 2. Which downstream units truly fail if upstream health is absent, versus merely
    needing upstream manifests applied first?
-3. Can `on-prem-keycloak-secrets` be reduced to a narrower prerequisite
-   contract, so Big Bang is not blocked on more health than it actually needs?
-4. Should `on-prem-platform-runtime` be decomposed before any `wait: true`
+3. Should `on-prem-platform-runtime` be decomposed before any `wait: true`
    change, so that gating decisions are made on smaller, coherent units?
 
 ## Suggested Next Step


### PR DESCRIPTION
## Summary
- Remove `wait: true` from `on-prem-keycloak-secrets` so Flux preserves apply ordering without health-gating on the Keycloak ExternalSecrets.
- Update the reconciliation docs and wait-justification table to reflect the new graph behavior.

## Why
- `on-prem-keycloak-secrets` was still health-gating on `keycloak-admin-credentials`, `keycloak-postgres-credentials`, and `private-registry`.
- Those ExternalSecrets all depend on the shared `vault-kv` provider-client path.
- That made Keycloak the remaining bootstrap choke point even after `platform-core` was unblocked.

## Validation
- `git diff --check`
- Confirmed the diff is limited to the Keycloak Kustomization and its supporting reconciliation docs.

## Impact
- `on-prem-keycloak-secrets` will now report Ready after resources are applied, without waiting for child health.
- `on-prem-bigbang` can advance on apply order and let the updated controller path continue converging.
