### PR TITLE
[codex] disable external-secrets token automount

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -150,7 +150,7 @@ addons:
                       labels:
                         app.kubernetes.io/version: "1.2.1"
                     spec:
-                      automountServiceAccountToken: true
+                      automountServiceAccountToken: false
                       securityContext:
                         runAsNonRoot: true
                         runAsUser: 65532

--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -339,7 +339,7 @@ addons:
                       labels:
                         app.kubernetes.io/version: "1.2.1"
                     spec:
-                      automountServiceAccountToken: true
+                      automountServiceAccountToken: false
     values:
       waitJob: false
       upstream:


### PR DESCRIPTION
This change removes the explicit `automountServiceAccountToken: true` setting from the Big Bang external-secrets render path so the deployment no longer violates the Kyverno `disallow-auto-mount-service-account-token` policy.

Why:
- The live `external-secrets` pod was being rendered with an explicit service account token mount that Kyverno flagged.
- The cluster still needs ESO to reconcile cleanly so `vault-kv` can become Ready and unblock downstream ExternalSecrets.

Impact:
- The rendered pod spec now aligns with the token policy.
- Flux can pick up the published source change on the next reconcile cycle.

Validation:
- `git diff --check`
- committed on `fix/platform-core-no-wait-gate`
- pushed to `origin`
