### PR TITLE
[codex] add external-secrets Istio injection annotation

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -147,6 +147,8 @@ addons:
                 spec:
                   template:
                     metadata:
+                      annotations:
+                        sidecar.istio.io/inject: "true"
                       labels:
                         app.kubernetes.io/version: "1.2.1"
                     spec:

--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -336,6 +336,8 @@ addons:
                 spec:
                   template:
                     metadata:
+                      annotations:
+                        sidecar.istio.io/inject: "true"
                       labels:
                         app.kubernetes.io/version: "1.2.1"
                     spec:


### PR DESCRIPTION
This change adds the Istio injection annotation to the `external-secrets` Deployment pod template in both Big Bang values files.

Why:
- The live `external-secrets` pod was still rendering without an `istio-proxy` sidecar.
- ESO’s Vault Kubernetes auth path depends on that mesh path to reach `vault-vault` cleanly.

Impact:
- The rendered pod template now requests Istio injection.
- Flux can pick up the updated source and converge the controller into the mesh.

Validation:
- `git diff --check`
- committed on `fix/platform-core-no-wait-gate`
- pushed to `origin`
