### PR TITLE
Remove unjustified wait gates from platform-core, keycloak-secrets, and platform-runtime

### DIFF
--- a/clusters/on-prem/platform-runtime-kustomization.yaml
+++ b/clusters/on-prem/platform-runtime-kustomization.yaml
@@ -14,5 +14,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  wait: true
   timeout: 20m


### PR DESCRIPTION
## Summary

Removes `wait: true` from three top-level Flux Kustomizations where health-gating was not load-bearing and was contributing to reconciliation stalls.

- `on-prem-platform-core`: foundational resources with no downstream health dependency; wait gate created a bootstrap deadlock with Vault/external-secrets
- `on-prem-keycloak-secrets`: apply ordering was sufficient; health-gating participated in the same deadlock
- `on-prem-platform-runtime`: currently blocking `on-prem-platform-services` in the live cluster; scope (Alloy, Vault, Kyverno policies, ArgoCD) is too broad for a single health gate; `timeout: 20m` retained for apply-phase safety

Also includes:
- External-secrets hardening: Istio injection annotation, token automount disabled
- Accumulated BigBang values hardening (ArgoCD, external-secrets pod security)
- Docs and residual debt audit

Informed by: #240, #255, #256
Closes: #256
Tracked under: #259

## Effect on live cluster

`on-prem-platform-services` is currently `False` blocked on `on-prem-platform-runtime` being stuck in reconciliation. This PR removes the gate and unblocks services immediately on merge.