### PR TITLE
Allow plaintext ingress to Vault for non-mesh clients

### DIFF
--- a/platform/vault/kustomization.yaml
+++ b/platform/vault/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - vault-aws-auto-unseal.sealed-secret.yaml
   - vault-reader-serviceaccount.yaml
   - clustersecretstore.yaml
+  - peer-authentication.yaml

--- a/platform/vault/peer-authentication.yaml
+++ b/platform/vault/peer-authentication.yaml
@@ -1,0 +1,11 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: vault-permissive-mtls
+  namespace: vault
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vault
+  mtls:
+    mode: PERMISSIVE


### PR DESCRIPTION
## Problem

`ClusterSecretStore/vault-kv` has been stuck `InvalidProviderConfig` with `unable to create client` since June 9th. Every ExternalSecret depending on it is broken, blocking secret sync across all platform namespaces.

Root cause: the vault pod has an Istio sidecar (`istio-proxy`) injected. Its iptables rules intercept all inbound traffic through Envoy before it reaches the Vault process. ESO has no Istio sidecar and cannot present mTLS credentials, so the Envoy proxy rejects the connection with RST — Vault itself never sees the request (confirmed: zero vault logs for ESO connection attempts).

## Fix

Add a `PeerAuthentication` in the vault namespace setting mTLS to `PERMISSIVE` for vault pods. This allows the Istio proxy to accept both mTLS (from mesh-enrolled pods) and plaintext (from ESO and other non-mesh clients).

## Effect

Once applied, ESO's Kubernetes auth login to Vault will succeed and `vault-kv` ClusterSecretStore will go Ready. All downstream ExternalSecrets (`argocd/private-registry`, `keycloak-postgres-credentials`, tenant ghcr secrets, etc.) will resume syncing.

Related: #263, #274, #275