### PR TITLE
Add Kyverno PolicyException for public-ingressgateway image tag

### DIFF
--- a/platform/policies/kyverno/kustomization.yaml
+++ b/platform/policies/kyverno/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - require-signed-ghcr-images.yaml
   - inject-required-labels.yaml
+  - public-ingressgateway-image-tag-exception.yaml

--- a/platform/policies/kyverno/public-ingressgateway-image-tag-exception.yaml
+++ b/platform/policies/kyverno/public-ingressgateway-image-tag-exception.yaml
@@ -1,0 +1,21 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: public-ingressgateway-image-tag
+  namespace: istio-gateway
+spec:
+  exceptions:
+    - policyName: disallow-image-tags
+      ruleNames:
+        - require-image-tag
+        - autogen-require-image-tag
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+            - Deployment
+          namespaces:
+            - istio-gateway
+          names:
+            - public-ingressgateway*


### PR DESCRIPTION
## Problem

`HelmRelease/bigbang/public-ingressgateway` is stuck `False` with:

> Could not determine release state: Deployment/istio-gateway/public-ingressgateway dry-run failed: admission webhook "validate.kyverno.svc-fail" denied the request: disallow-image-tags / autogen-require-image-tag

The BigBang Istio gateway chart uses an image without an explicit tag. The `disallow-image-tags` ClusterPolicy (managed by the `kyverno-policies` BigBang HelmRelease) started enforcing on June 5th after the policy lane split went live. Every Helm health reconciliation dry-run fails, keeping the HelmRelease permanently stuck.

## Fix

Add a `PolicyException` in the `istio-gateway` namespace exempting `public-ingressgateway` pods and deployments from the `require-image-tag` and `autogen-require-image-tag` rules. The chart image tag is controlled by BigBang upstream — this exception is the correct GitOps-side resolution until the chart is updated.

## Effect

Once applied, the Helm controller dry-run will pass Kyverno validation and the HelmRelease will be able to reconcile.

Related: #263