### PR TITLE
Wire ghcr-secret ExternalSecret into kyverno kustomization

### DIFF
--- a/platform/policies/kyverno/kustomization.yaml
+++ b/platform/policies/kyverno/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - require-signed-ghcr-images.yaml
   - inject-required-labels.yaml
   - public-ingressgateway-image-tag-exception.yaml
+  - ghcr-secret.external-secret.yaml


### PR DESCRIPTION
## Summary

- `ghcr-secret.external-secret.yaml` existed in `platform/policies/kyverno/` but was never referenced in the kustomization — the secret was never created in the kyverno namespace
- Without `ghcr-secret`, the `require-signed-ghcr-images` policy failed with `UNAUTHORIZED` when attempting keyless image signature verification against GHCR
- This caused Kyverno's fail-closed admission webhook to deny every Keycloak pod creation for the past 15 days
- Vault path `secret/platform/ghcr` confirmed present with valid credentials — ExternalSecret will sync on apply

## Test plan

- [ ] Flux applies the kustomization and ExternalSecret is created in the kyverno namespace
- [ ] `kubectl get secret ghcr-secret -n kyverno` returns the secret
- [ ] Kyverno PolicyViolation events for `require-signed-ghcr-images` stop showing UNAUTHORIZED
- [ ] `HelmRelease/keycloak` reconciles and `keycloak-keycloak-0` pod reaches Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)