### PR TITLE
Set runAsGroup: 1000 on Keycloak pod securityContext

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -364,6 +364,8 @@ addons:
                   template:
                     spec:
                       automountServiceAccountToken: false
+                      securityContext:
+                        runAsGroup: 1000
                       imagePullSecrets:
                         - name: private-registry
                       containers:


### PR DESCRIPTION
## Summary

- `require-non-root-group` ClusterPolicy (Enforce) blocks pods where `runAsGroup` is unset or 0
- The Keycloak chart does not set `runAsGroup`, and no existing mutation policy fills it
- Added `securityContext.runAsGroup: 1000` to the StatefulSet postRenderer patch in `values-foundation.yaml`
- Other enforce policies (`require-non-root-user`, `require-drop-all-capabilities`) are covered by existing mutation policies (`add-default-securitycontext`, `add-default-capability-drop`) which fire before validation

## Test plan

- [ ] Flux applies the foundation HelmRelease
- [ ] `keycloak-keycloak-0` pod reaches Running (no more `FailedCreate` events in keycloak namespace)
- [ ] `HelmRelease/keycloak` in bigbang namespace goes Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)