### PR TITLE
Exclude keycloak namespace from non-root and capabilities Kyverno policies

### DIFF
--- a/bigbang/policy/values-policy.yaml
+++ b/bigbang/policy/values-policy.yaml
@@ -171,6 +171,24 @@ kyvernoPolicies:
                   - DaemonSet
                 names:
                   - monitoring-monitoring-prometheus-node-exporter
+      require-non-root-group:
+        exclude:
+          any:
+            - resources:
+                namespaces:
+                  - keycloak
+      require-non-root-user:
+        exclude:
+          any:
+            - resources:
+                namespaces:
+                  - keycloak
+      restrict-capabilities:
+        exclude:
+          any:
+            - resources:
+                namespaces:
+                  - keycloak
       disallow-auto-mount-service-account-token:
         exclude:
           any:


### PR DESCRIPTION
## Summary

- Istio sidecar injection adds `istio-proxy` and `istio-init` containers to pods in the `keycloak` namespace
- `istio-init` runs as root with `NET_ADMIN`/`NET_RAW` capabilities to configure iptables rules
- This causes three Enforce-mode Kyverno policies to block the keycloak pod from ever being admitted: `require-non-root-group`, `require-non-root-user`, `restrict-capabilities`
- The keycloak container itself is fully compliant — the block is caused by Istio-injected containers
- Added namespace-level excludes for `keycloak` following the existing pattern used for `alloy`, `kiali`, and `monitoring` in `values-policy.yaml`

## Test plan

- [ ] `kyvernoPolicies` HelmRelease reconciles and ClusterPolicies are updated with the keycloak namespace exclude
- [ ] `HelmRelease/keycloak` in `bigbang` namespace reconciles successfully
- [ ] `keycloak-keycloak-0` pod reaches Running state
- [ ] No `FailedCreate` events in the `keycloak` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)