### PR TITLE
Fix argocd repo-server and dex-server volume patch to append not replace

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -573,33 +573,33 @@ addons:
                       drop:
                         - ALL
                 - op: add
-                  path: /spec/template/spec/volumes
+                  path: /spec/template/spec/volumes/-
                   value:
-                    - name: k8s-api-access
-                      projected:
-                        defaultMode: 420
-                        sources:
-                          - serviceAccountToken:
-                              audience: https://kubernetes.default.svc
-                              expirationSeconds: 3600
-                              path: token
-                          - configMap:
-                              items:
-                                - key: ca.crt
-                                  path: ca.crt
-                              name: kube-root-ca.crt
-                          - downwardAPI:
-                              items:
-                                - fieldRef:
-                                    apiVersion: v1
-                                    fieldPath: metadata.namespace
-                                  path: namespace
+                    name: k8s-api-access
+                    projected:
+                      defaultMode: 420
+                      sources:
+                        - serviceAccountToken:
+                            audience: https://kubernetes.default.svc
+                            expirationSeconds: 3600
+                            path: token
+                        - configMap:
+                            items:
+                              - key: ca.crt
+                                path: ca.crt
+                            name: kube-root-ca.crt
+                        - downwardAPI:
+                            items:
+                              - fieldRef:
+                                  apiVersion: v1
+                                  fieldPath: metadata.namespace
+                                path: namespace
                 - op: add
-                  path: /spec/template/spec/containers/0/volumeMounts
+                  path: /spec/template/spec/containers/0/volumeMounts/-
                   value:
-                    - name: k8s-api-access
-                      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                      readOnly: true
+                    name: k8s-api-access
+                    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                    readOnly: true
             - target:
                 group: apps
                 version: v1
@@ -626,32 +626,32 @@ addons:
                       drop:
                         - ALL
                 - op: add
-                  path: /spec/template/spec/volumes
+                  path: /spec/template/spec/volumes/-
                   value:
-                    - name: k8s-api-access
-                      projected:
-                        defaultMode: 420
-                        sources:
-                          - serviceAccountToken:
-                              audience: https://kubernetes.default.svc
-                              expirationSeconds: 3600
-                              path: token
-                          - configMap:
-                              items:
-                                - key: ca.crt
-                                  path: ca.crt
-                              name: kube-root-ca.crt
-                          - downwardAPI:
-                              items:
-                                - fieldRef:
-                                    apiVersion: v1
-                                    fieldPath: metadata.namespace
-                                  path: namespace
+                    name: k8s-api-access
+                    projected:
+                      defaultMode: 420
+                      sources:
+                        - serviceAccountToken:
+                            audience: https://kubernetes.default.svc
+                            expirationSeconds: 3600
+                            path: token
+                        - configMap:
+                            items:
+                              - key: ca.crt
+                                path: ca.crt
+                            name: kube-root-ca.crt
+                        - downwardAPI:
+                            items:
+                              - fieldRef:
+                                  apiVersion: v1
+                                  fieldPath: metadata.namespace
+                                path: namespace
                 - op: add
-                  path: /spec/template/spec/containers/0/volumeMounts
+                  path: /spec/template/spec/containers/0/volumeMounts/-
                   value:
-                    - name: k8s-api-access
-                      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                    name: k8s-api-access
+                    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
                       readOnly: true
             - target:
                 group: apps


### PR DESCRIPTION
## Summary

- The postRenderer patches for `argocd-argocd-repo-server` and `argocd-argocd-dex-server` used `op: add` on `/spec/template/spec/volumes`, which **replaces** the entire volumes array per JSON Patch RFC 6902
- This stripped chart-defined volumes: `var-files` (repo-server) and `static-files`/`dexconfig` (dex-server)
- The chart's init containers reference these volumes, so Kubernetes rejected the Deployment spec with "volume not found"
- Changed both patches to `path: /spec/template/spec/volumes/-` and `path: /spec/template/spec/containers/0/volumeMounts/-` to append the `k8s-api-access` entry rather than replace the array
- Same fix applied to the corresponding `volumeMounts` patches

## Test plan

- [ ] `bigbang-foundation` reconciles successfully
- [ ] `HelmRelease/argocd` in `bigbang` namespace goes Ready
- [ ] `argocd-argocd-repo-server` and `argocd-argocd-dex-server` pods reach Running
- [ ] `argocd-argocd-application-controller-0` readiness probe passes (port 8082)

🤖 Generated with [Claude Code](https://claude.com/claude-code)