### PR TITLE
Fix readOnly indentation in dex-server volumeMounts patch

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -652,7 +652,7 @@ addons:
                   value:
                     name: k8s-api-access
                     mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                      readOnly: true
+                    readOnly: true
             - target:
                 group: apps
                 version: v1


### PR DESCRIPTION
The previous commit left readOnly: true with 2 extra spaces of indentation in the dex-server volumeMounts patch, making it a sub-key of mountPath and causing a YAML parse error in the kustomize post-renderer.