### PR TITLE
Fix JSON Patch array-replace bug for all argocd volume patches

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -467,33 +467,33 @@ addons:
                       drop:
                         - ALL
                 - op: add
-                  path: /spec/template/spec/volumes
+                  path: /spec/template/spec/volumes/-
                   value:
-                    - name: k8s-api-access
-                      projected:
-                        defaultMode: 420
-                        sources:
-                          - serviceAccountToken:
-                              audience: https://kubernetes.default.svc
-                              expirationSeconds: 3600
-                              path: token
-                          - configMap:
-                              items:
-                                - key: ca.crt
-                                  path: ca.crt
-                              name: kube-root-ca.crt
-                          - downwardAPI:
-                              items:
-                                - fieldRef:
-                                    apiVersion: v1
-                                    fieldPath: metadata.namespace
-                                  path: namespace
+                    name: k8s-api-access
+                    projected:
+                      defaultMode: 420
+                      sources:
+                        - serviceAccountToken:
+                            audience: https://kubernetes.default.svc
+                            expirationSeconds: 3600
+                            path: token
+                        - configMap:
+                            items:
+                              - key: ca.crt
+                                path: ca.crt
+                            name: kube-root-ca.crt
+                        - downwardAPI:
+                            items:
+                              - fieldRef:
+                                  apiVersion: v1
+                                  fieldPath: metadata.namespace
+                                path: namespace
                 - op: add
-                  path: /spec/template/spec/containers/0/volumeMounts
+                  path: /spec/template/spec/containers/0/volumeMounts/-
                   value:
-                    - name: k8s-api-access
-                      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                      readOnly: true
+                    name: k8s-api-access
+                    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                    readOnly: true
             - target:
                 group: apps
                 version: v1
@@ -520,33 +520,33 @@ addons:
                       drop:
                         - ALL
                 - op: add
-                  path: /spec/template/spec/volumes
+                  path: /spec/template/spec/volumes/-
                   value:
-                    - name: k8s-api-access
-                      projected:
-                        defaultMode: 420
-                        sources:
-                          - serviceAccountToken:
-                              audience: https://kubernetes.default.svc
-                              expirationSeconds: 3600
-                              path: token
-                          - configMap:
-                              items:
-                                - key: ca.crt
-                                  path: ca.crt
-                              name: kube-root-ca.crt
-                          - downwardAPI:
-                              items:
-                                - fieldRef:
-                                    apiVersion: v1
-                                    fieldPath: metadata.namespace
-                                  path: namespace
+                    name: k8s-api-access
+                    projected:
+                      defaultMode: 420
+                      sources:
+                        - serviceAccountToken:
+                            audience: https://kubernetes.default.svc
+                            expirationSeconds: 3600
+                            path: token
+                        - configMap:
+                            items:
+                              - key: ca.crt
+                                path: ca.crt
+                            name: kube-root-ca.crt
+                        - downwardAPI:
+                            items:
+                              - fieldRef:
+                                  apiVersion: v1
+                                  fieldPath: metadata.namespace
+                                path: namespace
                 - op: add
-                  path: /spec/template/spec/containers/0/volumeMounts
+                  path: /spec/template/spec/containers/0/volumeMounts/-
                   value:
-                    - name: k8s-api-access
-                      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                      readOnly: true
+                    name: k8s-api-access
+                    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                    readOnly: true
             - target:
                 group: apps
                 version: v1
@@ -679,33 +679,33 @@ addons:
                       drop:
                         - ALL
                 - op: add
-                  path: /spec/template/spec/volumes
+                  path: /spec/template/spec/volumes/-
                   value:
-                    - name: k8s-api-access
-                      projected:
-                        defaultMode: 420
-                        sources:
-                          - serviceAccountToken:
-                              audience: https://kubernetes.default.svc
-                              expirationSeconds: 3600
-                              path: token
-                          - configMap:
-                              items:
-                                - key: ca.crt
-                                  path: ca.crt
-                              name: kube-root-ca.crt
-                          - downwardAPI:
-                              items:
-                                - fieldRef:
-                                    apiVersion: v1
-                                    fieldPath: metadata.namespace
-                                  path: namespace
+                    name: k8s-api-access
+                    projected:
+                      defaultMode: 420
+                      sources:
+                        - serviceAccountToken:
+                            audience: https://kubernetes.default.svc
+                            expirationSeconds: 3600
+                            path: token
+                        - configMap:
+                            items:
+                              - key: ca.crt
+                                path: ca.crt
+                            name: kube-root-ca.crt
+                        - downwardAPI:
+                            items:
+                              - fieldRef:
+                                  apiVersion: v1
+                                  fieldPath: metadata.namespace
+                                path: namespace
                 - op: add
-                  path: /spec/template/spec/containers/0/volumeMounts
+                  path: /spec/template/spec/containers/0/volumeMounts/-
                   value:
-                    - name: k8s-api-access
-                      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                      readOnly: true
+                    name: k8s-api-access
+                    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                    readOnly: true
             - target:
                 group: apps
                 version: v1
@@ -732,33 +732,33 @@ addons:
                       drop:
                         - ALL
                 - op: add
-                  path: /spec/template/spec/volumes
+                  path: /spec/template/spec/volumes/-
                   value:
-                    - name: k8s-api-access
-                      projected:
-                        defaultMode: 420
-                        sources:
-                          - serviceAccountToken:
-                              audience: https://kubernetes.default.svc
-                              expirationSeconds: 3600
-                              path: token
-                          - configMap:
-                              items:
-                                - key: ca.crt
-                                  path: ca.crt
-                              name: kube-root-ca.crt
-                          - downwardAPI:
-                              items:
-                                - fieldRef:
-                                    apiVersion: v1
-                                    fieldPath: metadata.namespace
-                                  path: namespace
+                    name: k8s-api-access
+                    projected:
+                      defaultMode: 420
+                      sources:
+                        - serviceAccountToken:
+                            audience: https://kubernetes.default.svc
+                            expirationSeconds: 3600
+                            path: token
+                        - configMap:
+                            items:
+                              - key: ca.crt
+                                path: ca.crt
+                            name: kube-root-ca.crt
+                        - downwardAPI:
+                            items:
+                              - fieldRef:
+                                  apiVersion: v1
+                                  fieldPath: metadata.namespace
+                                path: namespace
                 - op: add
-                  path: /spec/template/spec/containers/0/volumeMounts
+                  path: /spec/template/spec/containers/0/volumeMounts/-
                   value:
-                    - name: k8s-api-access
-                      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                      readOnly: true
+                    name: k8s-api-access
+                    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                    readOnly: true
             - target:
                 group: apps
                 version: v1


### PR DESCRIPTION
## Summary

- PR #291 fixed the `op: add` array-replace bug for `repo-server` and `dex-server`, but four more patches had the same issue: `argocd-server`, `applicationset-controller`, `notifications-controller`, and `application-controller` (StatefulSet)
- All four were using `op: add, path: /spec/template/spec/volumes` which replaces the entire array, stripping chart-defined volumes and causing pods to fail to start
- Changed all four to the append form (`path: /spec/template/spec/volumes/-`) and single-object `value` (no list wrapper), consistent with the repo-server and dex-server fixes
- `argocd-server` not becoming ready was the direct cause of the 10-minute Helm install timeout

## Root cause

JSON Patch RFC 6902: `op: add` on an existing array path replaces the array. Appending requires the `/-` suffix and a single object value (not a list).

## Test plan

- [ ] Flux reconciles `bigbang-foundation` without error after merge
- [ ] `argocd-argocd-server` pod reaches Ready state within install timeout
- [ ] `argocd-argocd-repo-server` pod reaches Ready state (already fixed in #291, verifying no regression)
- [ ] All argocd pods reach Ready state: app-controller, applicationset-controller, notifications-controller, dex-server, redis

🤖 Generated with [Claude Code](https://claude.com/claude-code)