### PR TITLE
Fix projected SA token audience for k3s cluster

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -474,7 +474,7 @@ addons:
                       defaultMode: 420
                       sources:
                         - serviceAccountToken:
-                            audience: https://kubernetes.default.svc
+                            audience: https://kubernetes.default.svc.cluster.local
                             expirationSeconds: 3600
                             path: token
                         - configMap:
@@ -527,7 +527,7 @@ addons:
                       defaultMode: 420
                       sources:
                         - serviceAccountToken:
-                            audience: https://kubernetes.default.svc
+                            audience: https://kubernetes.default.svc.cluster.local
                             expirationSeconds: 3600
                             path: token
                         - configMap:
@@ -580,7 +580,7 @@ addons:
                       defaultMode: 420
                       sources:
                         - serviceAccountToken:
-                            audience: https://kubernetes.default.svc
+                            audience: https://kubernetes.default.svc.cluster.local
                             expirationSeconds: 3600
                             path: token
                         - configMap:
@@ -633,7 +633,7 @@ addons:
                       defaultMode: 420
                       sources:
                         - serviceAccountToken:
-                            audience: https://kubernetes.default.svc
+                            audience: https://kubernetes.default.svc.cluster.local
                             expirationSeconds: 3600
                             path: token
                         - configMap:
@@ -686,7 +686,7 @@ addons:
                       defaultMode: 420
                       sources:
                         - serviceAccountToken:
-                            audience: https://kubernetes.default.svc
+                            audience: https://kubernetes.default.svc.cluster.local
                             expirationSeconds: 3600
                             path: token
                         - configMap:
@@ -739,7 +739,7 @@ addons:
                       defaultMode: 420
                       sources:
                         - serviceAccountToken:
-                            audience: https://kubernetes.default.svc
+                            audience: https://kubernetes.default.svc.cluster.local
                             expirationSeconds: 3600
                             path: token
                         - configMap:


### PR DESCRIPTION
## Summary

- All six `k8s-api-access` projected ServiceAccount token volumes in argocd patches specified `audience: https://kubernetes.default.svc`
- This k3s cluster issues tokens with issuer `https://kubernetes.default.svc.cluster.local` — the missing `.cluster.local` suffix caused every token to be rejected with 401 Unauthorized
- argocd-server was in a CrashLoopBackOff because it could not list/watch Secrets or ConfigMaps, so it never opened port 8080, causing the liveness probe to kill it repeatedly
- RBAC bindings were correct; the authentication layer was rejecting the token before RBAC was evaluated

## Root cause

Projected SA token `audience` must exactly match the API server's configured `--api-audiences`. k3s defaults to `https://kubernetes.default.svc.cluster.local`.

## Test plan

- [ ] Flux reconciles `bigbang-foundation` without error after merge
- [ ] argocd-server logs no longer show `Unauthorized` on Secret/ConfigMap watches
- [ ] argocd-server reaches Ready state within the 10-minute install timeout
- [ ] All argocd pods reach Ready state

🤖 Generated with [Claude Code](https://claude.com/claude-code)