### PR TITLE
Fix kiali: remove invalid schema field, add kiali pod SA token exclude

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -879,8 +879,6 @@ kiali:
                   spec:
                     automountServiceAccountToken: true
   values:
-    serviceAccount:
-      automountServiceAccountToken: false
     routes:
       inbound:
         kiali:

--- a/bigbang/policy/values-policy.yaml
+++ b/bigbang/policy/values-policy.yaml
@@ -223,6 +223,7 @@ kyvernoPolicies:
                   - Deployment
                 names:
                   - kiali-kiali-kiali-operator
+                  - kiali
             - resources:
                 namespaces:
                   - monitoring


### PR DESCRIPTION
## Summary

- `values-foundation.yaml`: Removed `serviceAccount.automountServiceAccountToken: false` from kiali values — this key is not permitted by the kiali chart's JSON schema, causing every install attempt to fail with `additional properties 'serviceAccount' not allowed`
- `values-policy.yaml`: Added `kiali` Deployment to the `disallow-auto-mount-service-account-token` exclude list. The kiali operator creates a Deployment named `kiali` that requires SA token access to watch Kubernetes resources for mesh topology visualization. Without this exclude, Kyverno would block the operator-managed pod after the schema error is resolved.

## Test plan

- [ ] Flux reconciles `bigbang-foundation` without schema error after merge
- [ ] kiali operator pod (`kiali-kiali-kiali-operator`) reaches Ready state
- [ ] kiali pod (`kiali`) reaches Ready state and is not blocked by Kyverno
- [ ] kiali HelmRelease transitions to `Ready: True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)