### PR TITLE
Add kiali namespace Kyverno excludes for security context policies

### DIFF
--- a/bigbang/policy/values-policy.yaml
+++ b/bigbang/policy/values-policy.yaml
@@ -188,18 +188,21 @@ kyvernoPolicies:
             - resources:
                 namespaces:
                   - keycloak
+                  - kiali
       require-non-root-user:
         exclude:
           any:
             - resources:
                 namespaces:
                   - keycloak
+                  - kiali
       restrict-capabilities:
         exclude:
           any:
             - resources:
                 namespaces:
                   - keycloak
+                  - kiali
       disallow-auto-mount-service-account-token:
         exclude:
           any:


### PR DESCRIPTION
## Summary

- Added `kiali` namespace to the `require-non-root-group`, `require-non-root-user`, and `restrict-capabilities` exclude lists
- No kiali-operator pods were being admitted during install — same pattern as the keycloak fix — Kyverno enforce policies block pods when the upstream chart does not set required security contexts on pod/container specs

## Test plan

- [ ] Merge PR #295 first (schema fix + SA token exclude), then this PR
- [ ] Reconcile `bigbang-policy` before `bigbang-foundation`
- [ ] kiali-operator pod reaches Ready state
- [ ] kiali HelmRelease transitions to `Ready: True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)