### PR TITLE
Add local-path-retain StorageClass and configure Vault to use it

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -225,6 +225,10 @@ addons:
           image:
             repository: docker.io/hashicorp/vault
             tag: 1.21.2
+          dataStorage:
+            storageClass: local-path-retain
+          auditStorage:
+            storageClass: local-path-retain
           standalone:
             config: |
               ui = true

--- a/platform/vault/kustomization.yaml
+++ b/platform/vault/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - vault-reader-serviceaccount.yaml
   - clustersecretstore.yaml
   - peer-authentication.yaml
+  - local-path-retain.storageclass.yaml

--- a/platform/vault/local-path-retain.storageclass.yaml
+++ b/platform/vault/local-path-retain.storageclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path-retain
+provisioner: rancher.io/local-path
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
## Summary

- Adds `local-path-retain` StorageClass (same `rancher.io/local-path` provisioner as default, `reclaimPolicy: Retain`)
- Configures Vault `dataStorage.storageClass` and `auditStorage.storageClass` to use it
- Adds the StorageClass to `platform/vault/kustomization.yaml` so it is applied before Vault HelmRelease runs

## Why

The default `local-path` StorageClass has `reclaimPolicy: Delete`. When Vault's PVC is deleted (namespace churn, uninstall, node lifecycle), the PV and all Vault data is permanently destroyed. This caused the data loss incident that required full Vault re-initialization and secret restoration.

## Manual steps required (do before or immediately after merge)

The two existing PVs are already provisioned with `Delete` policy. Patch them now:

```bash
kubectl patch pv pvc-bf5ee1df-3790-4f56-ba9a-de570796885d -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
kubectl patch pv pvc-cefc9366-3c01-4ce1-8ee8-b02b14905dbe -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
kubectl get pv | grep vault
```

Note: Changing `storageClass` in Vault values does not recreate existing PVCs — the existing PVCs and PVs are unchanged. The new StorageClass only applies to PVCs created on the next full Vault reinstall.

## Test plan

- [ ] Existing PVs patched to `Retain` manually
- [ ] `local-path-retain` StorageClass present in cluster after platform-core reconcile
- [ ] Vault HelmRelease remains `Ready: True` after foundation reconcile (no PVC recreation)
- [ ] `kubectl get pv | grep vault` shows `Retain` for both PVs

🤖 Generated with [Claude Code](https://claude.com/claude-code)