### PR TITLE
fix(airflow): harden executor pod security contexts

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -76,20 +76,6 @@ spec:
         ports:
           - name: http
             port: 8080
-      securityContexts:
-        container:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
-      waitForMigrations:
-        securityContexts:
-          container:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-
     # Scheduler configuration
     scheduler:
       replicas: 1
@@ -108,19 +94,6 @@ spec:
         limits:
           cpu: 1000m
           memory: 1Gi
-      securityContexts:
-        container:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
-      waitForMigrations:
-        securityContexts:
-          container:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
       logGroomerSidecar:
         enabled: false
 
@@ -139,21 +112,24 @@ spec:
         limits:
           cpu: 500m
           memory: 1Gi
-      securityContexts:
-        container:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
-      waitForMigrations:
-        securityContexts:
-          container:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
       logGroomerSidecar:
         enabled: false
+
+    # StatsD does not inherit the chart's global security contexts.
+    statsd:
+      securityContexts:
+        pod:
+          runAsUser: 65534
+          runAsGroup: 65534
+          runAsNonRoot: true
+          fsGroup: 65534
+        container:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            add: []
+            drop:
+              - ALL
 
     # DAG git-sync configuration
     dags:
@@ -172,8 +148,10 @@ spec:
             memory: 128Mi
         securityContexts:
           container:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
+              add: []
               drop:
                 - ALL
 
@@ -203,9 +181,14 @@ spec:
     securityContexts:
       pod:
         runAsUser: 50000
+        runAsGroup: 50000
+        runAsNonRoot: true
+        fsGroup: 50000
       containers:
+        runAsNonRoot: true
         allowPrivilegeEscalation: false
         capabilities:
+          add: []
           drop:
             - ALL
 


### PR DESCRIPTION
## Summary

- define non-root user and group settings for Airflow pod templates
- declare empty capability additions for worker and git-sync containers
- consolidate repeated component security contexts into the chart-wide definition
- explicitly harden StatsD, which does not inherit the global chart settings

## Root cause

Airflow's KubernetesExecutor worker template omitted `runAsGroup` and `runAsNonRoot`. Kyverno rejected worker pods before DAG tasks could start.

## Validation

- `helm lint` against Apache Airflow chart 1.15.0
- rendered every Airflow pod template and checked non-root user/group, dropped capabilities, and allowed capability additions
- `git diff --check`

Relates to #305. Live DAG validation remains required after reconciliation.