### PR TITLE
fix(policy): admit hardened Airflow pods

### DIFF
--- a/bigbang/policy/values-policy.yaml
+++ b/bigbang/policy/values-policy.yaml
@@ -203,6 +203,21 @@ kyvernoPolicies:
                 namespaces:
                   - keycloak
                   - kiali
+            # Kubernetes omits an explicitly empty capabilities.add list. The
+            # upstream policy treats that secure representation as a failure.
+            - resources:
+                namespaces:
+                  - platform
+                names:
+                  - airflow-*
+                  - listings-ingest-*
+            - resources:
+                namespaces:
+                  - listings-ingest
+                names:
+                  - extract-validate-*
+                  - load-postgres-*
+                  - dq-assertions-*
       disallow-auto-mount-service-account-token:
         exclude:
           any:

--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -124,6 +124,8 @@ spec:
           runAsNonRoot: true
           fsGroup: 65534
         container:
+          runAsUser: 65534
+          runAsGroup: 65534
           runAsNonRoot: true
           allowPrivilegeEscalation: false
           capabilities:
@@ -148,6 +150,8 @@ spec:
             memory: 128Mi
         securityContexts:
           container:
+            runAsUser: 50000
+            runAsGroup: 50000
             runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
@@ -185,6 +189,8 @@ spec:
         runAsNonRoot: true
         fsGroup: 50000
       containers:
+        runAsUser: 50000
+        runAsGroup: 50000
         runAsNonRoot: true
         allowPrivilegeEscalation: false
         capabilities:


### PR DESCRIPTION
## Summary

- set direct non-root user and group IDs on every Airflow-managed container
- exclude only Airflow executor and ETL pod name patterns from `restrict-capabilities`
- retain `require-drop-all-capabilities` enforcement for those pods

## Root cause

Kubernetes removes an explicitly empty `capabilities.add` list from stored pod specifications. Kyverno Policies 3.3.4-bb.19 and bb.24 use the same rule, which treats that secure omitted representation as a violation. Their pod-level non-root fallback also rejects these dynamically created pods despite valid pod security contexts.

## Validation

- Airflow chart 1.15.0 Helm lint
- rendered Airflow executor template inspection
- Big Bang 3.17.0 policy values render inspection
- `git diff --check`

Relates to #305. Live DAG validation remains required after reconciliation.