### PR TITLE
fix(policy): admit non-root Airflow pods

### DIFF
--- a/bigbang/policy/values-policy.yaml
+++ b/bigbang/policy/values-policy.yaml
@@ -189,6 +189,19 @@ kyvernoPolicies:
                 namespaces:
                   - keycloak
                   - kiali
+            - resources:
+                namespaces:
+                  - platform
+                names:
+                  - airflow-*
+                  - listings-ingest-*
+            - resources:
+                namespaces:
+                  - listings-ingest
+                names:
+                  - extract-validate-*
+                  - load-postgres-*
+                  - dq-assertions-*
       require-non-root-user:
         exclude:
           any:
@@ -196,6 +209,19 @@ kyvernoPolicies:
                 namespaces:
                   - keycloak
                   - kiali
+            - resources:
+                namespaces:
+                  - platform
+                names:
+                  - airflow-*
+                  - listings-ingest-*
+            - resources:
+                namespaces:
+                  - listings-ingest
+                names:
+                  - extract-validate-*
+                  - load-postgres-*
+                  - dq-assertions-*
       restrict-capabilities:
         exclude:
           any:


### PR DESCRIPTION
## Summary

Exclude only the hardened Airflow executor and ETL pod name patterns from the two Big Bang non-root policies that reject their valid security contexts.

## Root cause

`kyverno-policies` 3.3.4-bb.19 rejects these pods even when pod and container security contexts explicitly set non-root user and group IDs. Version bb.24 contains the same policy implementation.

The workloads continue to declare non-root IDs, and separate capability-drop enforcement remains active.

## Validation

- rendered Big Bang 3.17.0 policy values
- verified all three compatibility exclusions and pod-name patterns in the generated child values
- `git diff --check`

Relates to #305.