### PR TITLE
fix(bigbang): assign shared support package owners

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -10,6 +10,9 @@ gatekeeper:
 bbctl:
   enabled: false
 
+prometheusOperatorCRDs:
+  enabled: false
+
 kyverno:
   enabled: false
 
@@ -113,6 +116,8 @@ istioGateway:
       passthrough: {}
 
 addons:
+  metricsServer:
+    enabled: false
   gitlab:
     enabled: false
   gitlabRunner:

--- a/bigbang/observability/values-observability.yaml
+++ b/bigbang/observability/values-observability.yaml
@@ -8,6 +8,9 @@ gatekeeper:
 bbctl:
   enabled: false
 
+prometheusOperatorCRDs:
+  enabled: true
+
 kyverno:
   enabled: false
 
@@ -42,6 +45,8 @@ istioGateway:
   enabled: false
 
 addons:
+  metricsServer:
+    enabled: false
   gitlab:
     enabled: false
   gitlabRunner:

--- a/bigbang/policy/values-policy.yaml
+++ b/bigbang/policy/values-policy.yaml
@@ -8,6 +8,9 @@ gatekeeper:
 bbctl:
   enabled: false
 
+prometheusOperatorCRDs:
+  enabled: false
+
 kyverno:
   enabled: true
   postRenderers:
@@ -308,6 +311,8 @@ istioGateway:
   enabled: false
 
 addons:
+  metricsServer:
+    enabled: false
   gitlab:
     enabled: false
   gitlabRunner:

--- a/bigbang/values.yaml
+++ b/bigbang/values.yaml
@@ -14,6 +14,9 @@ gatekeeper:
 bbctl:
   enabled: false
 
+prometheusOperatorCRDs:
+  enabled: false
+
 kyverno:
   enabled: false  # Moved to bigbang-policy release
   postRenderers:
@@ -301,6 +304,8 @@ istioGateway:
 
 # Addons
 addons:
+  metricsServer:
+    enabled: false
   gitlab:
     enabled: false
   gitlabRunner:

--- a/clusters/on-prem/bigbang-policy-kustomization.yaml
+++ b/clusters/on-prem/bigbang-policy-kustomization.yaml
@@ -7,6 +7,7 @@ spec:
   dependsOn:
     - name: on-prem-bigbang-source
     - name: on-prem-bigbang-foundation
+    - name: on-prem-bigbang-observability
   interval: 10m
   path: ./bigbang/policy
   prune: true


### PR DESCRIPTION
## Summary

- make observability the sole Big Bang owner of `prometheus-operator-crds`
- explicitly disable Big Bang `metrics-server` everywhere because k3s owns the live metrics API
- explicitly disable both packages in every non-owner parent, including the legacy monolith
- make policy reconciliation depend directly on observability so monitoring CRDs exist first

## Live ownership

- `prometheus-operator-crds` is currently labeled as owned by `bigbang-observability`
- k3s owns the healthy `kube-system/metrics-server` deployment and metrics API
- no Big Bang `metrics-server` child source, HelmRelease, or Helm release exists

## Validation

Rendered all four parents independently with pinned Big Bang 3.17.0:

- legacy `bigbang`: neither package rendered
- foundation: neither package rendered
- observability: exactly one source and HelmRelease for `prometheus-operator-crds`
- policy: neither package rendered
- `git diff --check`

Relates to #306. Cluster reconciliation and live ownership verification remain separate acceptance steps.