### PR TITLE
fix(policy): restore monitoring compatibility exceptions

### DIFF
--- a/bigbang/policy/values-policy.yaml
+++ b/bigbang/policy/values-policy.yaml
@@ -164,6 +164,22 @@ kyvernoPolicies:
                   - alloy
                 names:
                   - alloy-upstream-add-finalizer*
+      disallow-tolerations:
+        exclude:
+          any:
+            - resources:
+                namespaces:
+                  - monitoring
+                names:
+                  - monitoring-monitoring-prometheus-node-exporter*
+      restrict-host-path-mount:
+        exclude:
+          any:
+            - resources:
+                namespaces:
+                  - monitoring
+                names:
+                  - monitoring-monitoring-prometheus-node-exporter*
       restrict-volume-types:
         exclude:
           any:


### PR DESCRIPTION
## Summary

Restore the two node-exporter policy exceptions that Big Bang normally derives when monitoring and Kyverno policies share one parent:

- `disallow-tolerations`
- `restrict-host-path-mount`

The existing `restrict-volume-types` exception remains unchanged.

## Root cause

Splitting monitoring into `bigbang-observability` and Kyverno policies into `bigbang-policy` removed conditional compatibility values derived from `monitoring.enabled`. After the shared CRD ownership handoff, monitoring drift recovery exposed the missing hostPath exception.

## Scope

The exclusions apply only to `monitoring-monitoring-prometheus-node-exporter*` in the `monitoring` namespace.

## Validation

Rendered the Big Bang 3.17.0 policy parent and verified all three node-exporter exclusions in the generated `kyverno-policies` child values. `git diff --check` passes.

Relates to #306.