### PR TITLE
fix(monitoring): restore admission and node exporter recovery

### DIFF
--- a/bigbang/observability/values-observability.yaml
+++ b/bigbang/observability/values-observability.yaml
@@ -86,6 +86,7 @@ monitoring:
         admissionWebhooks:
           enabled: true
           patch:
+            enabled: true
             image:
               registry: registry.k8s.io
               repository: ingress-nginx/kube-webhook-certgen

--- a/bigbang/policy/values-policy.yaml
+++ b/bigbang/policy/values-policy.yaml
@@ -186,10 +186,8 @@ kyvernoPolicies:
             - resources:
                 namespaces:
                   - monitoring
-                kinds:
-                  - DaemonSet
                 names:
-                  - monitoring-monitoring-prometheus-node-exporter
+                  - monitoring-monitoring-prometheus-node-exporter*
       disallow-image-tags:
         exclude:
           any:


### PR DESCRIPTION
## Summary

- make the node-exporter `restrict-volume-types` exception match generated Pod names
- explicitly enable the Prometheus Operator admission patch hook

## Root cause

After the shared CRD ownership handoff, monitoring drift recovery exposed two gaps:

- the existing volume exception matched only the exact DaemonSet, not its Pods
- drift correction recreated normal monitoring resources but not the admission hook's TLS Secret

The explicit patch enablement changes monitoring child values and triggers a real Helm upgrade so the certificate hook runs again.

## Validation

Rendered the Big Bang 3.17.0 policy and observability parents, parsed their generated child-value Secrets, and verified:

- `monitoring-monitoring-prometheus-node-exporter*` is excluded from `restrict-volume-types`
- `upstream.prometheusOperator.admissionWebhooks.patch.enabled` is `true`
- `git diff --check` passes

Relates to #306.