### PR TITLE
Set Vault PVCs to retain storage class

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -225,6 +225,10 @@ addons:
         enabled: false
       upstream:
         server:
+          dataStorage:
+            storageClass: local-path-retain
+          auditStorage:
+            storageClass: local-path-retain
           ha:
             apiAddr: "http://vault.vault.svc.cluster.local:8200"
           image:


### PR DESCRIPTION
## Summary
- set Vault data PVC template storage class to `local-path-retain`
- set Vault audit PVC template storage class to `local-path-retain`

## Rollout note
This changes the Vault StatefulSet `volumeClaimTemplates`, which Kubernetes does not patch in place. Do not merge as an unattended Flux rollout.

Coordinate merge with a live migration step that preserves the existing PVCs, recreates only the StatefulSet object, and then verifies Vault status and `vault-kv` recovery.

## Validation
- parsed `bigbang/foundation/values-foundation.yaml` as YAML
- ran `git diff --check`

Closes #275 after coordinated rollout verification.