### PR TITLE
Add Vault Kyverno policy exclusions

### DIFF
--- a/bigbang/policy/values-policy.yaml
+++ b/bigbang/policy/values-policy.yaml
@@ -219,6 +219,11 @@ kyvernoPolicies:
                   - extract-validate-*
                   - load-postgres-*
                   - dq-assertions-*
+            - resources:
+                namespaces:
+                  - vault
+                names:
+                  - vault-vault-*
       require-non-root-user:
         exclude:
           any:
@@ -239,6 +244,11 @@ kyvernoPolicies:
                   - extract-validate-*
                   - load-postgres-*
                   - dq-assertions-*
+            - resources:
+                namespaces:
+                  - vault
+                names:
+                  - vault-vault-*
       restrict-capabilities:
         exclude:
           any:
@@ -261,6 +271,11 @@ kyvernoPolicies:
                   - extract-validate-*
                   - load-postgres-*
                   - dq-assertions-*
+            - resources:
+                namespaces:
+                  - vault
+                names:
+                  - vault-vault-*
       disallow-auto-mount-service-account-token:
         exclude:
           any:
@@ -299,6 +314,13 @@ kyvernoPolicies:
                   - ServiceAccount
                 names:
                   - alloy-upstream-add-finalizer
+            - resources:
+                namespaces:
+                  - vault
+                kinds:
+                  - ServiceAccount
+                names:
+                  - vault-vault
 
 eckOperator:
   enabled: false


### PR DESCRIPTION
## Summary
- add Vault pod exclusions for `require-non-root-group`
- add Vault pod exclusions for `require-non-root-user`
- add Vault pod exclusions for `restrict-capabilities`
- add Vault service account exclusion for `disallow-auto-mount-service-account-token`

## Why
During the coordinated Vault StatefulSet recreation for #275, the recreated `vault-vault-0` pod was blocked by Kyverno even though the pre-existing pod had been grandfathered. These exclusions make the GitOps policy state match the live recovery state.

## Validation
- parsed `bigbang/policy/values-policy.yaml` as YAML
- ran `git diff --check`

Related to #275.