### PR TITLE
feat: MinIO direct Flux ownership for listings-ingest object storage (#206)

### DIFF
--- a/bigbang/minio/gitrepository-minio-operator.yaml
+++ b/bigbang/minio/gitrepository-minio-operator.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: minio-operator
+  namespace: bigbang
+spec:
+  interval: 10m
+  url: https://repo1.dso.mil/big-bang/product/packages/minio-operator.git
+  ref:
+    # render-parity: confirm tag from BigBang 3.17.0 addons.minioOperator package before activating
+    tag: RENDER_PARITY_REQUIRED

--- a/bigbang/minio/gitrepository-minio.yaml
+++ b/bigbang/minio/gitrepository-minio.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: minio
+  namespace: bigbang
+spec:
+  interval: 10m
+  url: https://repo1.dso.mil/big-bang/product/packages/minio.git
+  ref:
+    # render-parity: confirm tag from BigBang 3.17.0 addons.minio package before activating
+    tag: RENDER_PARITY_REQUIRED

--- a/bigbang/minio/helmrelease-minio-operator.yaml
+++ b/bigbang/minio/helmrelease-minio-operator.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: minio-operator
+  namespace: bigbang
+spec:
+  interval: 10m
+  driftDetection:
+    mode: enabled
+  chart:
+    spec:
+      chart: ./chart
+      sourceRef:
+        kind: GitRepository
+        name: minio-operator
+        namespace: bigbang
+      interval: 10m
+  timeout: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: bigbang-minio-operator-values
+      valuesKey: values.yaml

--- a/bigbang/minio/helmrelease-minio.yaml
+++ b/bigbang/minio/helmrelease-minio.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: minio
+  namespace: bigbang
+spec:
+  dependsOn:
+    - name: minio-operator
+      namespace: bigbang
+  interval: 10m
+  driftDetection:
+    mode: enabled
+  chart:
+    spec:
+      chart: ./chart
+      sourceRef:
+        kind: GitRepository
+        name: minio
+        namespace: bigbang
+      interval: 10m
+  timeout: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: bigbang-minio-values
+      valuesKey: values.yaml

--- a/bigbang/minio/kustomization.yaml
+++ b/bigbang/minio/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - gitrepository-minio-operator.yaml
+  - gitrepository-minio.yaml
+  - helmrelease-minio-operator.yaml
+  - helmrelease-minio.yaml
+  - minio-root-credentials.externalsecret.yaml
+
+configurations:
+  - kustomizeconfig.yaml
+
+configMapGenerator:
+  - name: bigbang-minio-operator-values
+    namespace: bigbang
+    files:
+      - values.yaml=values-minio-operator.yaml
+  - name: bigbang-minio-values
+    namespace: bigbang
+    files:
+      - values.yaml=values-minio.yaml

--- a/bigbang/minio/kustomizeconfig.yaml
+++ b/bigbang/minio/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+# Teach Kustomize to rewrite ConfigMap references in Flux HelmRelease CRDs
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/bigbang/minio/minio-root-credentials.externalsecret.yaml
+++ b/bigbang/minio/minio-root-credentials.externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: minio-root-credentials
+  namespace: minio
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: minio-root-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    - secretKey: accesskey
+      remoteRef:
+        key: platform/minio/root
+        property: accesskey
+    - secretKey: secretkey
+      remoteRef:
+        key: platform/minio/root
+        property: secretkey

--- a/bigbang/minio/namespace.yaml
+++ b/bigbang/minio/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio-operator
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio

--- a/bigbang/minio/values-minio-operator.yaml
+++ b/bigbang/minio/values-minio-operator.yaml
@@ -1,0 +1,14 @@
+# MinIO Operator values for on-prem environment
+# Images override BigBang defaults to avoid registry1.dso.mil dependency.
+# render-parity: image tags must be confirmed against BigBang 3.17.0 package output.
+
+istio:
+  enabled: false
+
+upstream:
+  operator:
+    image:
+      repository: quay.io/minio/operator
+      # render-parity: confirm tag from BigBang 3.17.0 minio-operator package
+      tag: RENDER_PARITY_REQUIRED
+    imagePullSecrets: []

--- a/bigbang/minio/values-minio.yaml
+++ b/bigbang/minio/values-minio.yaml
@@ -1,0 +1,27 @@
+# MinIO tenant values for on-prem environment
+# Provisions a single-tenant MinIO instance with the listings-ingest bucket.
+# Images override BigBang defaults to avoid registry1.dso.mil dependency.
+# render-parity: image tags must be confirmed against BigBang 3.17.0 package output.
+
+istio:
+  enabled: false
+
+upstream:
+  tenant:
+    image:
+      repository: quay.io/minio/minio
+      # render-parity: confirm tag from BigBang 3.17.0 minio package
+      tag: RENDER_PARITY_REQUIRED
+    imagePullSecrets: []
+    name: listings-ingest-tenant
+    namespace: minio
+    pools:
+      - name: pool-0
+        servers: 1
+        volumesPerServer: 1
+        size: 10Gi
+        storageClassName: local-path
+    buckets:
+      - name: listings-ingest
+    configSecret:
+      name: minio-root-credentials

--- a/clusters/on-prem/bigbang-minio-kustomization.yaml
+++ b/clusters/on-prem/bigbang-minio-kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: on-prem-bigbang-minio
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: on-prem-bigbang-source
+    - name: on-prem-bigbang-foundation
+  interval: 10m
+  path: ./bigbang/minio
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  timeout: 15m

--- a/clusters/on-prem/kustomization.yaml
+++ b/clusters/on-prem/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - bigbang-foundation-kustomization.yaml
   - bigbang-policy-kustomization.yaml
   - bigbang-observability-kustomization.yaml
+  - bigbang-minio-kustomization.yaml
   - bigbang-kustomization.yaml
   - platform-runtime-kustomization.yaml
   - platform-services-kustomization.yaml

--- a/tenants/listings-ingest/kustomization.yaml
+++ b/tenants/listings-ingest/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - serviceaccount.yaml
   - ghcr-secret.external-secret.yaml
   - listings-ingest-db.externalsecret.yaml
+  - listings-ingest-storage.externalsecret.yaml

--- a/tenants/listings-ingest/listings-ingest-storage.externalsecret.yaml
+++ b/tenants/listings-ingest/listings-ingest-storage.externalsecret.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: listings-ingest-storage
+  namespace: listings-ingest
+  labels:
+    zave.io/workload: listings-ingest
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: listings-ingest-storage
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    - secretKey: MINIO_ACCESS_KEY
+      remoteRef:
+        key: tenants/listings-ingest/storage
+        property: MINIO_ACCESS_KEY
+    - secretKey: MINIO_SECRET_KEY
+      remoteRef:
+        key: tenants/listings-ingest/storage
+        property: MINIO_SECRET_KEY
+    - secretKey: MINIO_ENDPOINT
+      remoteRef:
+        key: tenants/listings-ingest/storage
+        property: MINIO_ENDPOINT


### PR DESCRIPTION
## Summary

- Adds `bigbang/minio/` as a directly owned Flux package family (MinIO Operator + Tenant), aligned with the accepted BigBang boundary strategy (#258) — no umbrella addons path used
- Registers `on-prem-bigbang-minio` Flux Kustomization depending on `bigbang-source` and `bigbang-foundation`
- Provisions `minio-root-credentials` ExternalSecret in the `minio` namespace (Vault path: `platform/minio/root`)
- Provisions `listings-ingest-storage` ExternalSecret in the `listings-ingest` namespace (Vault path: `tenants/listings-ingest/storage`)
- All images override BigBang defaults to `quay.io/minio/operator` and `quay.io/minio/minio` — no registry1.dso.mil dependency

## Render-Parity Blockers (must resolve before activation)

Package chart tags in both GitRepository objects are set to `RENDER_PARITY_REQUIRED`. Before this branch is activated on-cluster, the following must be completed by an operator with cluster access:

1. Render the BigBang 3.17.0 chart with `addons.minioOperator.enabled: true` and `addons.minio.enabled: true` to confirm the generated package chart tags for both packages
2. Replace `RENDER_PARITY_REQUIRED` in `gitrepository-minio-operator.yaml` and `gitrepository-minio.yaml` with the confirmed tags
3. Render the proposed direct package releases using the confirmed chart tags
4. Compare target namespace, dependencies, remediation config, and support resources — classify every difference as intentional, equivalent, or blocking
5. Confirm no active umbrella owner exists for these packages before activating the direct owner
6. Capture controller, runtime, and user-visible evidence after handoff

## Vault Secrets Required

The following paths must be provisioned in Vault before ESO can sync (tracked in #205):

- `platform/minio/root` — keys: `accesskey`, `secretkey`
- `tenants/listings-ingest/storage` — keys: `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_ENDPOINT`

## Out of Scope

- ETL job changes (`etl/sources/csv.py`, `requirements-runner.txt`) and Airflow HelmRelease env var updates live in the tenant and airflow repos — follow-on after this PR stabilizes
- MinIO ingress / UI exposure
- Vault policy IaC (#205)

## Related

- Closes #206
- Architecture alignment review: #206 (comment)
- BigBang boundary strategy: #258
- Package ownership inventory: #300
- Vault policy IaC: #205