### PR TITLE
feat: set ETL_INPUT_PATH to MinIO S3 path in Airflow HelmRelease (#206)

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -43,6 +43,8 @@ spec:
         value: "listings-ingest"
       - name: ETL_IMAGE
         value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:f7ef312a5db7379af01c0dcbbaf789373465434621a73454edd26bfaeaa42dff"
+      - name: ETL_INPUT_PATH
+        value: "s3://listings-ingest/input/listings.csv"
 
     # External PostgreSQL configuration
     postgresql:


### PR DESCRIPTION
## Summary

Adds `ETL_INPUT_PATH=s3://listings-ingest/input/listings.csv` to the Airflow HelmRelease env block so the `listings_ingest` DAG reads its input from MinIO rather than the local volume placeholder.

The DAG already reads this env var on startup — no DAG code change required here.

## Dependencies (must be in place before Airflow reconciles)

- MinIO running and bucket created — gitops PR #316 (pending render-parity sign-off)
- `listings-ingest-storage` Secret synced by ESO — gitops PR #316 + kubernetes-platform-infrastructure PR #59
- ETL image updated with boto3 — listings-ingest PR #32

## Related

- Closes zavestudios/gitops#206
- gitops PR #316 — MinIO Flux ownership
- listings-ingest PR #32 — S3 read support in ETL job