### PR TITLE
fix: resolve MinIO render-parity placeholders (#206)

### DIFF
--- a/bigbang/minio/gitrepository-minio-operator.yaml
+++ b/bigbang/minio/gitrepository-minio-operator.yaml
@@ -8,5 +8,4 @@ spec:
   interval: 10m
   url: https://repo1.dso.mil/big-bang/product/packages/minio-operator.git
   ref:
-    # render-parity: confirm tag from BigBang 3.17.0 addons.minioOperator package before activating
-    tag: RENDER_PARITY_REQUIRED
+    tag: 7.1.1-bb.4

--- a/bigbang/minio/gitrepository-minio.yaml
+++ b/bigbang/minio/gitrepository-minio.yaml
@@ -8,5 +8,4 @@ spec:
   interval: 10m
   url: https://repo1.dso.mil/big-bang/product/packages/minio.git
   ref:
-    # render-parity: confirm tag from BigBang 3.17.0 addons.minio package before activating
-    tag: RENDER_PARITY_REQUIRED
+    tag: 7.1.1-bb.16

--- a/bigbang/minio/values-minio-operator.yaml
+++ b/bigbang/minio/values-minio-operator.yaml
@@ -1,6 +1,6 @@
 # MinIO Operator values for on-prem environment
-# Images override BigBang defaults to avoid registry1.dso.mil dependency.
-# render-parity: image tags must be confirmed against BigBang 3.17.0 package output.
+# Images override BigBang 3.17.0 defaults (registry1.dso.mil/ironbank/opensource/minio/operator:v7.1.1)
+# to avoid registry1.dso.mil dependency. Intentional parity difference.
 
 istio:
   enabled: false
@@ -9,6 +9,5 @@ upstream:
   operator:
     image:
       repository: quay.io/minio/operator
-      # render-parity: confirm tag from BigBang 3.17.0 minio-operator package
-      tag: RENDER_PARITY_REQUIRED
+      tag: v7.1.1
     imagePullSecrets: []

--- a/bigbang/minio/values-minio.yaml
+++ b/bigbang/minio/values-minio.yaml
@@ -1,7 +1,7 @@
 # MinIO tenant values for on-prem environment
 # Provisions a single-tenant MinIO instance with the listings-ingest bucket.
-# Images override BigBang defaults to avoid registry1.dso.mil dependency.
-# render-parity: image tags must be confirmed against BigBang 3.17.0 package output.
+# Images override BigBang 3.17.0 defaults (registry1.dso.mil/ironbank/opensource/minio/minio:RELEASE.2025-10-15T17-29-55Z)
+# to avoid registry1.dso.mil dependency. Intentional parity difference.
 
 istio:
   enabled: false
@@ -10,8 +10,7 @@ upstream:
   tenant:
     image:
       repository: quay.io/minio/minio
-      # render-parity: confirm tag from BigBang 3.17.0 minio package
-      tag: RENDER_PARITY_REQUIRED
+      tag: RELEASE.2025-10-15T17-29-55Z
     imagePullSecrets: []
     name: listings-ingest-tenant
     namespace: minio


### PR DESCRIPTION
## Summary

Closes the offline render-parity gate opened in PR #316 by rendering BigBang 3.17.0 locally with both MinIO addons enabled and confirming the generated package chart tags and default image refs.

## Render evidence

Command:
```
helm template bigbang /tmp/bigbang-3.17.0/chart \
  --namespace bigbang \
  --set addons.minioOperator.enabled=true \
  --set addons.minio.enabled=true \
  --set domain=zavestudios.com \
  --skip-tests
```

| Package | Chart tag | BigBang default image |
|---|---|---|
| minio-operator | 7.1.1-bb.4 | registry1.dso.mil/ironbank/opensource/minio/operator:v7.1.1 |
| minio | 7.1.1-bb.16 | registry1.dso.mil/ironbank/opensource/minio/minio:RELEASE.2025-10-15T17-29-55Z |

## Changes

- `gitrepository-minio-operator.yaml` — tag: `7.1.1-bb.4`
- `gitrepository-minio.yaml` — tag: `7.1.1-bb.16`
- `values-minio-operator.yaml` — pins `quay.io/minio/operator:v7.1.1`; documents registry1 override as intentional parity difference
- `values-minio.yaml` — pins `quay.io/minio/minio:RELEASE.2025-10-15T17-29-55Z`; documents registry1 override as intentional parity difference

## Remaining validation (requires cluster access)

Per the boundary strategy, controller, runtime, and user-visible checks must be completed by an operator:

- **Requires cluster access:** confirm Flux `minio-operator` and `minio` HelmReleases reach Ready
- **Requires cluster access:** confirm MinIO Tenant CR is healthy and `listings-ingest` bucket exists
- **Requires cluster access:** confirm `listings-ingest-storage` ExternalSecret has synced
- **Requires cluster access:** trigger the `listings_ingest` DAG and verify end-to-end run

## Related

- gitops#206
- gitops PR #316 — initial MinIO Flux ownership