### PR TITLE
fix: add targetNamespace to MinIO HelmReleases (#206)

### DIFF
--- a/bigbang/minio/helmrelease-minio-operator.yaml
+++ b/bigbang/minio/helmrelease-minio-operator.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: bigbang
 spec:
   interval: 10m
+  targetNamespace: minio-operator
   driftDetection:
     mode: enabled
   chart:

--- a/bigbang/minio/helmrelease-minio.yaml
+++ b/bigbang/minio/helmrelease-minio.yaml
@@ -9,6 +9,7 @@ spec:
     - name: minio-operator
       namespace: bigbang
   interval: 10m
+  targetNamespace: minio
   driftDetection:
     mode: enabled
   chart:


### PR DESCRIPTION
## Problem

`minio-operator` HelmRelease failing with:

```
admission webhook "validate.kyverno.svc-fail" denied the request:
resource Deployment/bigbang/minio-operator was blocked due to the following policies
disallow-namespaces: validate-namespace: The namespace used for this resource is not allowed.
```

Without `targetNamespace`, Flux installs the chart into the `bigbang` namespace. Kyverno's `disallow-namespaces` policy blocks workloads from running there.

## Fix

- `helmrelease-minio-operator.yaml` — `targetNamespace: minio-operator`
- `helmrelease-minio.yaml` — `targetNamespace: minio`

Both namespaces are already declared in `namespace.yaml`.

## Related

- gitops#206