### PR TITLE
fix: override MinIO operator sidecar image to avoid registry1 (#206)

### DIFF
--- a/bigbang/minio/values-minio-operator.yaml
+++ b/bigbang/minio/values-minio-operator.yaml
@@ -1,6 +1,7 @@
 # MinIO Operator values for on-prem environment
-# Images override BigBang 3.17.0 defaults (registry1.dso.mil/ironbank/opensource/minio/operator:v7.1.1)
-# to avoid registry1.dso.mil dependency. Intentional parity difference.
+# Images override BigBang 3.17.0 defaults to avoid registry1.dso.mil dependency. Intentional parity differences:
+#   operator:     registry1.dso.mil/.../operator:v7.1.1      -> quay.io/minio/operator:v7.1.1
+#   sidecarImage: registry1.dso.mil/.../operator-sidecar:v7.0.1 -> quay.io/minio/operator:v7.0.1
 
 istio:
   enabled: false
@@ -10,4 +11,7 @@ upstream:
     image:
       repository: quay.io/minio/operator
       tag: v7.1.1
+    sidecarImage:
+      repository: quay.io/minio/operator
+      tag: v7.0.1
     imagePullSecrets: []


### PR DESCRIPTION
## Problem

Tenant pod `listings-ingest-tenant-pool-0-0` stuck in `Init:ImagePullBackOff`:

```
Pulling image "registry1.dso.mil/ironbank/opensource/minio/operator-sidecar:v7.0.1"
Unable to retrieve some image pull secrets (private-registry)
```

The MinIO Operator injects a sidecar init container into every tenant pod. The sidecar image defaults to the IronBank registry and was not covered by the existing image overrides.

## Fix

Adds `upstream.operator.sidecarImage` override in `values-minio-operator.yaml`:

```
registry1.dso.mil/ironbank/opensource/minio/operator-sidecar:v7.0.1
  -> quay.io/minio/operator:v7.0.1
```

## Outstanding (Vault secret — operator action required)

The `minio-root-credentials` ExternalSecret is also failing:

```
error processing spec.data[0] (key: platform/minio/root), err: Secret does not exist
```

The Vault path `platform/minio/root` needs to be populated with `accesskey` and `secretkey` before the Tenant can initialize. Run via Vault CLI or UI:

```
vault kv put secret/platform/minio/root accesskey=<value> secretkey=<value>
```

## Related

- gitops#206
- gitops PR #319