### PR TITLE
fix: correct MinIO root credentials secret format (#206)

### DIFF
--- a/bigbang/minio/minio-root-credentials.externalsecret.yaml
+++ b/bigbang/minio/minio-root-credentials.externalsecret.yaml
@@ -14,6 +14,10 @@ spec:
     creationPolicy: Owner
     template:
       type: Opaque
+      data:
+        config.env: |
+          export MINIO_ROOT_USER={{ .accesskey }}
+          export MINIO_ROOT_PASSWORD={{ .secretkey }}
   data:
     - secretKey: accesskey
       remoteRef:

--- a/bigbang/minio/values-minio.yaml
+++ b/bigbang/minio/values-minio.yaml
@@ -24,3 +24,4 @@ upstream:
       - name: listings-ingest
     configSecret:
       name: minio-root-credentials
+      existingSecret: true


### PR DESCRIPTION
## Problem

MinIO Operator reporting `empty tenant credentials` even after the Vault secret was provisioned. The root cause was a secret format mismatch.

The MinIO Tenant chart (v7.1.1) expects the credentials secret to have a single `config.env` key:

```
export MINIO_ROOT_USER=<value>
export MINIO_ROOT_PASSWORD=<value>
```

Our ExternalSecret was producing `accesskey` and `secretkey` as separate keys, which the Operator does not recognise.

## Fix

- `minio-root-credentials.externalsecret.yaml` — adds an ESO template that renders the two Vault values into a single `config.env` key in the correct MinIO env format
- `values-minio.yaml` — adds `existingSecret: true` to `configSecret` so the Helm chart does not create a competing secret with the same name

## After merge

Force ESO to re-sync immediately:

```bash
kubectl -n minio annotate externalsecret minio-root-credentials \
  force-sync=$(date +%s) --overwrite
```

Then check Tenant state:

```bash
kubectl -n minio get tenant listings-ingest-tenant \
  -o jsonpath='{.status.currentState}'
```

## Related

- gitops#206