### PR TITLE
fix: bump MinIO sidecar image to v7.1.1 (#206)

### DIFF
--- a/bigbang/minio/values-minio-operator.yaml
+++ b/bigbang/minio/values-minio-operator.yaml
@@ -1,7 +1,7 @@
 # MinIO Operator values for on-prem environment
 # Images override BigBang 3.17.0 defaults to avoid registry1.dso.mil dependency. Intentional parity differences:
 #   operator:     registry1.dso.mil/.../operator:v7.1.1      -> quay.io/minio/operator:v7.1.1
-#   sidecarImage: registry1.dso.mil/.../operator-sidecar:v7.0.1 -> quay.io/minio/operator:v7.0.1
+#   sidecarImage: registry1.dso.mil/.../operator-sidecar:v7.0.1 -> quay.io/minio/operator:v7.1.1 (v7.0.1 missing validate subcommand)
 
 istio:
   enabled: false
@@ -13,5 +13,5 @@ upstream:
       tag: v7.1.1
     sidecarImage:
       repository: quay.io/minio/operator
-      tag: v7.0.1
+      tag: v7.1.1
     imagePullSecrets: []


### PR DESCRIPTION
## Problem

`validate-arguments` init container crashing with:

```
'validate' is not a console sub-command. See 'console --help'
```

The Operator v7.1.1 injects an init container that calls `console validate`. The `validate` subcommand was not present in `quay.io/minio/operator:v7.0.1` (added between v7.0.1 and v7.1.1 upstream). The IronBank sidecar image at `v7.0.1` is a different build that includes it; the upstream quay.io image at that tag does not.

## Fix

Bumps `sidecarImage.tag` from `v7.0.1` to `v7.1.1` so operator and sidecar are at the same version.

## Related

- gitops#206
- gitops PR #320 — original sidecar image override