### PR TITLE
fix: disable BigBang wait job in MinIO tenant values

### DIFF
--- a/bigbang/minio/values-minio.yaml
+++ b/bigbang/minio/values-minio.yaml
@@ -7,6 +7,9 @@
 istio:
   enabled: false
 
+waitJob:
+  enabled: false
+
 upstream:
   tenant:
     image:


### PR DESCRIPTION
The wait job pulls registry1.dso.mil/ironbank/.../kubectl:v1.33. No public equivalent needed — disabling the job and verifying tenant health directly via kubectl instead.