### PR TITLE
feat: bump ETL runner image with S3 support (#206)

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
       - name: AIRFLOW_RUN_NAMESPACE
         value: "listings-ingest"
       - name: ETL_IMAGE
-        value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:f7ef312a5db7379af01c0dcbbaf789373465434621a73454edd26bfaeaa42dff"
+        value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:b9158e9696b8c5253a863546e3d16fa755d92d28dc0bb580f195ecad54e85da9"
       - name: ETL_INPUT_PATH
         value: "s3://listings-ingest/input/listings.csv"
 


### PR DESCRIPTION
## Summary

Updates `ETL_IMAGE` in the Airflow HelmRelease to the image built from listings-ingest PR #32, which adds boto3 and S3-aware input reading to the ETL job.

| | Digest |
|---|---|
| Previous | `sha256:f7ef312a5db7379af01c0dcbbaf789373465434621a73454edd26bfaeaa42dff` |
| New | `sha256:b9158e9696b8c5253a863546e3d16fa755d92d28dc0bb580f195ecad54e85da9` |

## Related

- Closes gitops#206
- listings-ingest PR #32 — S3 read support