### PR TITLE
fix: deploy MinIO TLS ETL runner image

### DIFF
--- a/platform/services/airflow/helmrelease.yaml
+++ b/platform/services/airflow/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
       - name: AIRFLOW_RUN_NAMESPACE
         value: "listings-ingest"
       - name: ETL_IMAGE
-        value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:b9158e9696b8c5253a863546e3d16fa755d92d28dc0bb580f195ecad54e85da9"
+        value: "ghcr.io/zavestudios/zavestudios-etl-runner@sha256:b36ce8987f822e1fba5eae424da9fd2280ca6f176d818835eab88cf51dfa3c17"
       - name: ETL_INPUT_PATH
         value: "s3://listings-ingest/input/listings.csv"
 


### PR DESCRIPTION
## Summary

- Update Airflow `ETL_IMAGE` to the post-merge listings-ingest runner digest from `main` build `28141803030`.
- Deploys the image containing the MinIO S3 TLS/path-style client fix.

## Testing

- Parsed `platform/services/airflow/helmrelease.yaml` with Python YAML loader.
- Confirmed the digest came from the successful `listings-ingest` main build.

## Notes

- This is required because Airflow git-sync picked up the DAG change, but Flux owns the ETL runner image reference through the Airflow HelmRelease.
