### PR TITLE
Add listings-ingest Postgres runtime

### DIFF
--- a/tenants/listings-ingest/kustomization.yaml
+++ b/tenants/listings-ingest/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ghcr-secret.external-secret.yaml
   - listings-ingest-db.externalsecret.yaml
   - listings-ingest-storage.externalsecret.yaml
+  - postgres-statefulset.yaml

--- a/tenants/listings-ingest/postgres-statefulset.yaml
+++ b/tenants/listings-ingest/postgres-statefulset.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: listings-ingest
+  labels:
+    app: postgres
+    app.kubernetes.io/version: "16-alpine"
+    zave.io/workload: listings-ingest
+spec:
+  ports:
+  - port: 5432
+    name: postgres
+  clusterIP: None
+  selector:
+    app: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: listings-ingest
+  labels:
+    app: postgres
+    app.kubernetes.io/version: "16-alpine"
+    zave.io/workload: listings-ingest
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/version: "16-alpine"
+        zave.io/workload: listings-ingest
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+      containers:
+      - name: postgres
+        image: docker.io/library/postgres:16-alpine
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        env:
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: listings-ingest-db
+              key: DB_NAME
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: listings-ingest-db
+              key: DB_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: listings-ingest-db
+              key: DB_PASSWORD
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        ports:
+        - containerPort: 5432
+          name: postgres
+        volumeMounts:
+        - name: postgres-data
+          mountPath: /var/lib/postgresql/data
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+  volumeClaimTemplates:
+  - metadata:
+      name: postgres-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
## Summary

- Add a tenant-local Postgres headless Service and StatefulSet for listings-ingest
- Wire Postgres initialization to the existing listings-ingest-db ExternalSecret values
- Include the new manifest in the listings-ingest tenant kustomization

## Testing

- kubectl kustomize tenants/listings-ingest
- git diff --cached --check

## Notes

- This matches the current DB_HOST value: postgres.listings-ingest.svc.cluster.local
- Local Kyverno CLI is not installed, so policy validation is left to CI
