### PR TITLE
fix(observability): allow Mia OTLP to Alloy receiver

### DIFF
--- a/.github/workflows/kyverno-validate.yml
+++ b/.github/workflows/kyverno-validate.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'platform/services/**/helmrelease.yaml'
+      - 'platform/runtime/**/*.yaml'
       - 'platform/policies/kyverno/enforce/**'
       - 'tenants/**/*.yaml'
 
@@ -36,12 +37,19 @@ jobs:
             | grep -E '^tenants/.*\.yaml$' \
             | grep -v 'kustomization\.yaml' || true)
 
+          platform_manifests=$(git diff --name-only "${base_ref}...HEAD" \
+            | grep -E '^platform/runtime/.*\.yaml$' \
+            | grep -v 'kustomization\.yaml' || true)
+
           {
             echo "helmreleases<<EOF"
             echo "$helmreleases"
             echo "EOF"
             echo "tenant_manifests<<EOF"
             echo "$tenant_manifests"
+            echo "EOF"
+            echo "platform_manifests<<EOF"
+            echo "$platform_manifests"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -85,6 +93,18 @@ jobs:
             mkdir -p "$dest"
             cp "$manifest" "$dest/"
           done <<< "${{ steps.changed.outputs.tenant_manifests }}"
+
+      - name: Stage platform runtime manifests
+        if: steps.changed.outputs.platform_manifests != ''
+        run: |
+          mkdir -p rendered-manifests
+
+          while IFS= read -r manifest; do
+            [[ -z "$manifest" ]] && continue
+            dest="rendered-manifests/$(dirname "$manifest")"
+            mkdir -p "$dest"
+            cp "$manifest" "$dest/"
+          done <<< "${{ steps.changed.outputs.platform_manifests }}"
 
       - name: Check for staged manifests
         id: check

--- a/platform/runtime/alloy-receiver/kustomization.yaml
+++ b/platform/runtime/alloy-receiver/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - configmap.yaml
   - alloy.yaml
+  - networkpolicy-mia-otlp.yaml

--- a/platform/runtime/alloy-receiver/networkpolicy-mia-otlp.yaml
+++ b/platform/runtime/alloy-receiver/networkpolicy-mia-otlp.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-mia-otlp-to-alloy-receiver
+  namespace: alloy
+  labels:
+    app.kubernetes.io/name: alloy-receiver
+    app.kubernetes.io/part-of: alloy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-receiver
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mia
+          podSelector:
+            matchLabels:
+              app: mia
+      ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP


### PR DESCRIPTION
Summary
- add a narrow NetworkPolicy allowing Mia pods to send OTLP to alloy-receiver on 4317/4318
- wire the policy into the explicit alloy-receiver runtime overlay

Context
- Mia resolves alloy-receiver correctly, but direct pod/service probes to 4317/4318 were refused
- alloy namespace has default ingress deny and no tenant ingress rule for OTLP
- this keeps the first fix narrow to Mia while we validate the end-user observability path

Validation
- git diff --check
- kustomize build platform/runtime