### PR TITLE
fix(observability): expose Grafana operator UI

### DIFF
--- a/platform/runtime/grafana-virtualservice.yaml
+++ b/platform/runtime/grafana-virtualservice.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  hosts:
+    - grafana-on-prem.zavestudios.com
+  gateways:
+    - istio-gateway/public-ingressgateway
+  http:
+    - route:
+        - destination:
+            host: monitoring-grafana.monitoring.svc.cluster.local
+            port:
+              number: 80

--- a/platform/runtime/kustomization.yaml
+++ b/platform/runtime/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - grafana-virtualservice.yaml
   - alloy-receiver/
   - alloy-hook-support/
   - ../vault/


### PR DESCRIPTION
Summary
- add a platform runtime VirtualService for grafana-on-prem.zavestudios.com
- route the operator hostname through the public Istio gateway to monitoring-grafana:80

Context
- Grafana is deployed and healthy in namespace monitoring
- Cloudflare Access/DNS exist for grafana-on-prem.zavestudios.com
- live cluster had no Grafana VirtualService, so browser access could authenticate but had no in-cluster route

Validation
- git diff --check
- kustomize build platform/runtime