### PR TITLE
fix(observability): allow ingress gateway to Grafana

### DIFF
--- a/platform/runtime/grafana-networkpolicy.yaml
+++ b/platform/runtime/grafana-networkpolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-public-ingressgateway-to-grafana
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: monitoring-grafana
+      app.kubernetes.io/name: grafana
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-gateway
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: public-ingressgateway
+      ports:
+        - port: 3000
+          protocol: TCP

--- a/platform/runtime/kustomization.yaml
+++ b/platform/runtime/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - grafana-virtualservice.yaml
+  - grafana-networkpolicy.yaml
   - alloy-receiver/
   - alloy-hook-support/
   - ../vault/


### PR DESCRIPTION
Summary
- add a NetworkPolicy allowing the public Istio ingress gateway to reach Grafana
- allow traffic from istio-gateway/public-ingressgateway to monitoring-grafana on port 3000

Context
- Grafana is deployed and has ready endpoints
- grafana-on-prem now reaches Istio, but Envoy reports upstream connection refused
- monitoring namespace has default ingress deny and no allow rule from istio-gateway to Grafana

Validation
- git diff --check
- kustomize build platform/runtime