### PR TITLE
fix(observability): allow Alloy receiver to export traces to Tempo

### DIFF
--- a/platform/runtime/alloy-receiver/kustomization.yaml
+++ b/platform/runtime/alloy-receiver/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - configmap.yaml
   - alloy.yaml
   - networkpolicy-mia-otlp.yaml
+  - networkpolicy-tempo-export.yaml

--- a/platform/runtime/alloy-receiver/networkpolicy-tempo-export.yaml
+++ b/platform/runtime/alloy-receiver/networkpolicy-tempo-export.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-alloy-receiver-egress-to-tempo
+  namespace: alloy
+  labels:
+    app.kubernetes.io/name: alloy-receiver
+    app.kubernetes.io/part-of: alloy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-receiver
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tempo
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: tempo
+      ports:
+        - port: 4317
+          protocol: TCP

--- a/platform/runtime/kustomization.yaml
+++ b/platform/runtime/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - grafana-virtualservice.yaml
   - grafana-networkpolicy.yaml
+  - tempo-networkpolicy.yaml
   - alloy-receiver/
   - alloy-hook-support/
   - ../vault/

--- a/platform/runtime/tempo-networkpolicy.yaml
+++ b/platform/runtime/tempo-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-alloy-receiver-to-tempo-otlp
+  namespace: tempo
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tempo
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: alloy
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alloy-receiver
+      ports:
+        - port: 4317
+          protocol: TCP


### PR DESCRIPTION
Summary
- allow alloy-receiver egress to Tempo on OTLP gRPC port 4317
- allow Tempo ingress from alloy-receiver on OTLP gRPC port 4317

Context
- synthetic OTLP POST from Mia to alloy-receiver returned 200 OK
- Tempo search still returned no traces
- existing Tempo policy allowed 4317 only from app.kubernetes.io/name=alloy-logs, not alloy-receiver
- alloy namespace also has default egress deny

Validation
- git diff --check
- kustomize build platform/runtime