### PR TITLE
fix(mia): reconcile diagnostics OTEL config

### DIFF
--- a/tenants/mia/deployment.yaml
+++ b/tenants/mia/deployment.yaml
@@ -93,6 +93,28 @@ spec:
           cfg.commands = cfg.commands || {};
           cfg.commands.ownerAllowFrom = JSON.parse(process.env.OPENCLAW_OWNER_ALLOW_FROM);
 
+          cfg.plugins = cfg.plugins || {};
+          cfg.plugins.allow = Array.from(new Set([
+            ...(Array.isArray(cfg.plugins.allow) ? cfg.plugins.allow : []),
+            'diagnostics-otel',
+          ]));
+          cfg.plugins.entries = cfg.plugins.entries || {};
+          cfg.plugins.entries['diagnostics-otel'] = {
+            ...(cfg.plugins.entries['diagnostics-otel'] || {}),
+            enabled: true,
+          };
+
+          cfg.diagnostics = cfg.diagnostics || {};
+          cfg.diagnostics.enabled = true;
+          cfg.diagnostics.otel = {
+            ...(cfg.diagnostics.otel || {}),
+            enabled: true,
+            protocol: 'http/protobuf',
+            traces: true,
+            metrics: true,
+            logs: true,
+          };
+
           fs.writeFileSync(path, JSON.stringify(cfg, null, 2) + '\n');
           NODE
 


### PR DESCRIPTION
Summary
- reconcile diagnostics OTEL settings into Mia's PVC-backed OpenClaw config during init
- ensure the diagnostics-otel plugin entry is enabled and allowlisted

Context
- end-user OTEL verification proved Mia -> Alloy -> Tempo -> Grafana with synthetic traces
- real Mia traces only appeared after enabling diagnostics-otel live in the PVC-backed config
- this makes that setting durable across restarts/reconciliation

Validation
- git diff --check
- kustomize build tenants/mia