### PR TITLE
fix(mia): reconcile required OpenClaw plugins

### DIFF
--- a/tenants/mia/deployment.yaml
+++ b/tenants/mia/deployment.yaml
@@ -94,15 +94,18 @@ spec:
           cfg.commands.ownerAllowFrom = JSON.parse(process.env.OPENCLAW_OWNER_ALLOW_FROM);
 
           cfg.plugins = cfg.plugins || {};
+          const requiredPlugins = ['anthropic', 'diagnostics-otel', 'ollama', 'whatsapp'];
           cfg.plugins.allow = Array.from(new Set([
             ...(Array.isArray(cfg.plugins.allow) ? cfg.plugins.allow : []),
-            'diagnostics-otel',
+            ...requiredPlugins,
           ]));
           cfg.plugins.entries = cfg.plugins.entries || {};
-          cfg.plugins.entries['diagnostics-otel'] = {
-            ...(cfg.plugins.entries['diagnostics-otel'] || {}),
-            enabled: true,
-          };
+          for (const plugin of requiredPlugins) {
+            cfg.plugins.entries[plugin] = {
+              ...(cfg.plugins.entries[plugin] || {}),
+              enabled: true,
+            };
+          }
 
           cfg.diagnostics = cfg.diagnostics || {};
           cfg.diagnostics.enabled = true;


### PR DESCRIPTION
Summary
- reconcile the full required Mia OpenClaw plugin allowlist, not diagnostics-otel alone
- enable anthropic, diagnostics-otel, ollama, and whatsapp entries during PVC config reconciliation

Context
- #341 made diagnostics OTEL durable, but live validation showed the PVC allowlist then contained only diagnostics-otel
- that hid the WhatsApp channel from `openclaw channels list`
- this preserves diagnostics OTEL while restoring the required runtime plugin set

Validation
- git diff --check
- kustomize build tenants/mia