### PR TITLE
Harden Alloy receiver observability coverage

### DIFF
--- a/docs/observability-alert-routing-verification.md
+++ b/docs/observability-alert-routing-verification.md
@@ -1,0 +1,54 @@
+# Observability Alert Routing Verification
+
+## Purpose
+
+Define the current Formation verification path for Grafana and Alertmanager
+alert routing without creating synthetic incidents or requiring destructive
+runtime changes.
+
+## Current Posture
+
+During Formation, Grafana alerting and Alertmanager UI visibility are the
+minimum accepted operator surface.
+
+The current intentional routing posture is default-only until a durable
+operator notification target is chosen and represented in Git. A future
+notification route must declare:
+
+- contact point type
+- destination ownership
+- secret source
+- notification policy matchers
+- non-production test procedure
+
+Do not add ad hoc contact points through the Grafana UI as the durable
+configuration path.
+
+## Non-Destructive Verification
+
+Use Grafana through the approved operator access path.
+
+1. Open Grafana.
+2. Navigate to Alerting -> Alert rules.
+3. Confirm datasource-managed alert rules are visible.
+4. Navigate to Alerting -> Contact points.
+5. Confirm the current contact point inventory.
+6. Navigate to Alerting -> Notification policies.
+7. Confirm the default policy tree is visible.
+8. Confirm whether any Zave-specific contact point or notification policy
+   exists.
+
+Expected Formation result:
+
+- alert rules are visible
+- Contact points and Notification policies pages load
+- default-only routing is acceptable if no Git-managed notification target has
+  been selected
+
+## Follow-Up Trigger
+
+Create a follow-up implementation issue when a real operator notification
+target is chosen.
+
+That implementation should configure routing through Git-managed values or
+manifests and include a non-production test alert path.

--- a/platform/runtime/alloy-receiver/kustomization.yaml
+++ b/platform/runtime/alloy-receiver/kustomization.yaml
@@ -5,4 +5,6 @@ resources:
   - configmap.yaml
   - alloy.yaml
   - networkpolicy-mia-otlp.yaml
+  - networkpolicy-prometheus-scrape.yaml
   - networkpolicy-tempo-export.yaml
+  - servicemonitor.yaml

--- a/platform/runtime/alloy-receiver/networkpolicy-prometheus-scrape.yaml
+++ b/platform/runtime/alloy-receiver/networkpolicy-prometheus-scrape.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scrape-alloy-receiver
+  namespace: alloy
+  labels:
+    app.kubernetes.io/name: alloy-receiver
+    app.kubernetes.io/part-of: alloy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-receiver
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 12345
+          protocol: TCP

--- a/platform/runtime/alloy-receiver/servicemonitor.yaml
+++ b/platform/runtime/alloy-receiver/servicemonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: alloy-receiver
+  namespace: alloy
+  labels:
+    app.kubernetes.io/name: alloy-receiver
+    app.kubernetes.io/part-of: alloy
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-receiver
+  namespaceSelector:
+    matchNames:
+      - alloy
+  endpoints:
+    - port: http-metrics
+      path: /metrics
+      interval: 30s


### PR DESCRIPTION
## Summary

- Add a platform-owned `ServiceMonitor` for `alloy-receiver` so Prometheus can discover the receiver metrics endpoint.
- Add a matching NetworkPolicy allowing Prometheus in `monitoring` to scrape the Alloy receiver HTTP metrics port.
- Document current default-only Alertmanager routing posture and a non-destructive Grafana UI verification procedure.

## Related

- Addresses zavestudios/gitops#343
- Follow-up to zavestudios/gitops#190

## Testing

- `kustomize build platform/runtime/alloy-receiver`
- `git diff --check main...HEAD`

## Post-merge verification

**Requires cluster access:**

- Confirm Prometheus target visibility for `up{namespace="alloy", service="alloy-receiver"}`.
- Confirm Grafana Alerting pages load and default-only routing remains visible as documented.