### PR TITLE
Add ArgoCD Keycloak SSO config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Reconciliation order is managed by Flux `dependsOn` relationships under `cluster
 - `docs/platform-stability-gap-analysis-2026-06.md`: Pause-and-inventory plan for stabilizing the current platform baseline before deeper app work.
 - `docs/image-registry-mappings.md`: Public image mapping used for Big Bang sandbox deployments.
 - `docs/keycloak-recovery-notes.md`: Recovery notes for the Keycloak bring-up, including manual incident actions and durable follow-up fixes.
+- `docs/argocd-sso-keycloak-runbook.md`: Normal login, role mapping, break-glass, and rollback flow for ArgoCD SSO through Keycloak.
 - `docs/rabbitmq-capability-evaluation.md`: Cross-repo decision record for the OpenShift Local RabbitMQ proving exercise and the current defer-promote recommendation.
 - `docs/vault-hardening-plan.md`: Vault persistence, lifecycle, and recovery hardening plan for the current environment.
 - `docs/vault-migration-plan.md`: Vault, External Secrets Operator, and Sealed Secrets migration plan.

--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -4,6 +4,10 @@
 
 domain: zavestudios.com
 
+sso:
+  name: Keycloak
+  url: https://sso-on-prem.zavestudios.com/auth/realms/zavestudios
+
 gatekeeper:
   enabled: false
 
@@ -399,6 +403,13 @@ addons:
                         - name: private-registry
   argocd:
     enabled: true
+    sso:
+      enabled: true
+      client_id: argocd
+      client_secret: "$argocd-keycloak-oidc:clientSecret"
+      groups: |
+        g, zave-platform-admins, role:admin
+        g, zave-platform-operators, role:readonly
     postRenderers:
       - kustomize:
           patches:

--- a/docs/argocd-sso-keycloak-runbook.md
+++ b/docs/argocd-sso-keycloak-runbook.md
@@ -1,0 +1,115 @@
+# ArgoCD Keycloak SSO Runbook
+
+## Status
+
+GitOps config added for `zavestudios/gitops#90`.
+
+Runtime verification still requires cluster access.
+
+## Authority
+
+Flux manages the Big Bang foundation release that installs ArgoCD and Keycloak.
+ArgoCD does not manage itself.
+
+The ArgoCD SSO model is declared in:
+
+- `bigbang/foundation/values-foundation.yaml`
+- `platform/argocd/external-secrets.yaml`
+
+## Normal Login
+
+Use:
+
+```text
+https://argocd-on-prem.zavestudios.com
+```
+
+Select the Keycloak SSO login option.
+
+Expected identity provider:
+
+```text
+https://sso-on-prem.zavestudios.com/auth/realms/zavestudios
+```
+
+## Role Mapping
+
+ArgoCD RBAC maps Keycloak groups as follows:
+
+```text
+zave-platform-admins     -> role:admin
+zave-platform-operators  -> role:readonly
+```
+
+The Keycloak `argocd` client must emit a group claim compatible with the Big
+Bang ArgoCD SSO client scope.
+
+## Secret Source
+
+The ArgoCD OIDC client secret is sourced from Vault through External Secrets:
+
+```text
+Vault path:        platform/services/argocd/oidc
+Vault property:    clientSecret
+Kubernetes Secret: argocd/argocd-keycloak-oidc
+ArgoCD reference:  $argocd-keycloak-oidc:clientSecret
+```
+
+Do not commit the client secret to Git.
+
+## Verification
+
+**Requires cluster access:**
+
+```bash
+kubectl -n argocd get externalsecret argocd-keycloak-oidc
+kubectl -n argocd get secret argocd-keycloak-oidc \
+  -o jsonpath='{.metadata.labels.app\.kubernetes\.io/part-of}{"\n"}'
+kubectl -n argocd get configmap argocd-cm -o yaml
+kubectl -n argocd get configmap argocd-rbac-cm -o yaml
+kubectl -n bigbang get helmrelease bigbang-foundation
+```
+
+Confirm:
+
+- `argocd-keycloak-oidc` is synced and labeled `app.kubernetes.io/part-of=argocd`.
+- `argocd-cm` contains `oidc.config` with the Keycloak issuer.
+- `argocd-rbac-cm` contains the expected group mappings.
+- Keycloak login succeeds for an admin user.
+- Keycloak login succeeds for a read-only/operator user.
+- Login still works after an `argocd-server` pod restart.
+
+## Break-Glass Local Admin
+
+Local admin remains a break-glass path until Keycloak SSO is verified.
+
+Use it only for recovery when SSO or Keycloak is unavailable. Any manual runtime
+action must be backported into Git or documented as incident follow-up.
+
+**Requires cluster access:**
+
+```bash
+kubectl -n argocd get secret argocd-initial-admin-secret
+kubectl -n argocd get secret argocd-secret
+```
+
+If a password reset is required, capture the command and reason in the incident
+notes before closing the incident.
+
+## Rollback
+
+Rollback is Git-first:
+
+1. Revert the `addons.argocd.sso` block in `bigbang/foundation/values-foundation.yaml`.
+2. Revert `argocd-keycloak-oidc` from `platform/argocd/external-secrets.yaml` if it is not needed.
+3. Merge through PR and allow Flux to reconcile.
+
+**Requires cluster access:**
+
+```bash
+flux reconcile kustomization on-prem-bigbang-foundation -n flux-system
+kubectl -n bigbang get helmrelease bigbang-foundation
+kubectl -n argocd get configmap argocd-cm -o yaml
+```
+
+Do not remove or disable local admin as part of the initial SSO rollout.

--- a/platform/argocd/external-secrets.yaml
+++ b/platform/argocd/external-secrets.yaml
@@ -24,3 +24,39 @@ spec:
       remoteRef:
         key: platform/ghcr
         property: .dockerconfigjson
+
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-keycloak-oidc
+  namespace: argocd
+  labels:
+    zave.io/component: argocd
+    zave.io/tier: platform-service
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-kv
+    kind: ClusterSecretStore
+  target:
+    name: argocd-keycloak-oidc
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      metadata:
+        labels:
+          app.kubernetes.io/name: argocd-keycloak-oidc
+          app.kubernetes.io/part-of: argocd
+          zave.io/component: argocd
+          zave.io/tier: platform-service
+      type: Opaque
+      data:
+        clientSecret: "{{ .clientSecret }}"
+  data:
+    - secretKey: clientSecret
+      remoteRef:
+        key: platform/services/argocd/oidc
+        property: clientSecret


### PR DESCRIPTION
## Summary

- Enables Big Bang-managed ArgoCD SSO through the on-prem Keycloak realm
- Adds an ExternalSecret-backed ArgoCD OIDC client secret reference
- Documents normal login, RBAC mapping, break-glass, verification, and rollback flow

## Related Issue

Closes #90

## Testing

- `git diff --check`
- `kubectl kustomize platform/argocd`
- `kubectl kustomize clusters/on-prem`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' bigbang/foundation/values-foundation.yaml platform/argocd/external-secrets.yaml`
- `helm template bigbang-foundation /tmp/bigbang-3.17.0/chart --namespace bigbang --values bigbang/foundation/values-foundation.yaml --output-dir /tmp/bigbang-foundation-render --skip-tests`
- `rg -n "oidc.config|issuer:|clientID:|clientSecret:|policy.csv|zave-platform|requestedScopes|keycloakClientSecret" /tmp/bigbang-foundation-render/bigbang/templates/argocd/values.yaml`

## Notes

Runtime SSO validation still requires cluster access and a populated Vault value at `platform/services/argocd/oidc` property `clientSecret`.