### PR TITLE
fix: override ArgoCD OIDC requestedScopes to use standard scopes

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -407,6 +407,7 @@ addons:
       enabled: true
       client_id: argocd
       client_secret: "$argocd-keycloak-oidc:clientSecret"
+      requestedScopes: '["openid", "profile", "email", "groups"]'
       groups: |
         g, zave-platform-admins, role:admin
         g, zave-platform-operators, role:readonly


### PR DESCRIPTION
## Summary

Big Bang injects `"ArgoCD"` as a requested OIDC scope by default. Keycloak rejects the login flow when that scope does not exist in the realm.

This PR overrides `requestedScopes` to standard scopes: `openid`, `profile`, `email`, `groups`. The `groups` scope supplies the claim needed for ArgoCD RBAC group mapping.

A corresponding Group Membership mapper named `groups` was added to the `argocd` client in Keycloak to emit the groups claim.

## Related

Follows on from #345 (ArgoCD Keycloak SSO config).
Closes #90.

## Test plan

- [ ] Flux reconciles `bigbang-foundation` HelmRelease after merge
- [ ] ArgoCD `argocd-cm` shows updated `requestedScopes`
- [ ] Login via Keycloak succeeds for `xavier`
- [ ] `xavier` lands with admin role in ArgoCD
- [ ] Login survives `argocd-server` pod restart