### PR TITLE
fix: set ArgoCD oidc.config via upstream values to correct requestedScopes

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -407,7 +407,6 @@ addons:
       enabled: true
       client_id: argocd
       client_secret: "$argocd-keycloak-oidc:clientSecret"
-      requestedScopes: '["openid", "profile", "email", "groups"]'
       groups: |
         g, zave-platform-admins, role:admin
         g, zave-platform-operators, role:readonly
@@ -855,6 +854,14 @@ addons:
         image:
           repository: quay.io/argoproj/argocd
       upstream:
+        configs:
+          cm:
+            oidc.config: |
+              name: Keycloak
+              issuer: https://sso-on-prem.zavestudios.com/auth/realms/zavestudios
+              clientID: argocd
+              clientSecret: $argocd-keycloak-oidc:clientSecret
+              requestedScopes: ["openid", "profile", "email", "groups"]
         dex:
           image:
             repository: ghcr.io/dexidp/dex

--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -407,6 +407,7 @@ addons:
       enabled: true
       client_id: argocd
       client_secret: "$argocd-keycloak-oidc:clientSecret"
+      requestedScopes: '["openid", "profile", "email", "groups"]'
       groups: |
         g, zave-platform-admins, role:admin
         g, zave-platform-operators, role:readonly


### PR DESCRIPTION
## Summary

- Big Bang's SSO template does not expose `requestedScopes` as a passable field — `sso.requestedScopes` was silently ignored
- Pass the full `oidc.config` block directly through `addons.argocd.values.upstream.configs.cm` so the scopes reach `argocd-cm`
- Removes the ineffective `requestedScopes` from the `sso` block

## Related

Follows on from #347.
Closes #90.

## Test plan

- [ ] Flux reconciles ArgoCD HelmRelease after merge
- [ ] `argocd-cm` shows `requestedScopes: ["openid", "profile", "email", "groups"]`
- [ ] Keycloak login succeeds for `xavier` without scope error
- [ ] `xavier` lands with admin role
- [ ] Login survives pod restart