### PR TITLE
fix: remove groups from ArgoCD requestedScopes

### DIFF
--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -407,7 +407,6 @@ addons:
       enabled: true
       client_id: argocd
       client_secret: "$argocd-keycloak-oidc:clientSecret"
-      requestedScopes: '["openid", "profile", "email", "groups"]'
       groups: |
         g, zave-platform-admins, role:admin
         g, zave-platform-operators, role:readonly

--- a/bigbang/foundation/values-foundation.yaml
+++ b/bigbang/foundation/values-foundation.yaml
@@ -861,7 +861,7 @@ addons:
               issuer: https://sso-on-prem.zavestudios.com/auth/realms/zavestudios
               clientID: argocd
               clientSecret: $argocd-keycloak-oidc:clientSecret
-              requestedScopes: ["openid", "profile", "email", "groups"]
+              requestedScopes: ["openid", "profile", "email"]
         dex:
           image:
             repository: ghcr.io/dexidp/dex


### PR DESCRIPTION
## Summary

Keycloak rejects the entire scope request when an unknown scope name is included. `groups` is not a named client scope in Keycloak — it is emitted as a claim through the Group Membership mapper on the `argocd-dedicated` client scope automatically. Removing it from `requestedScopes` unblocks the login flow.

## Related

Follows on from #348.
Closes #90.

## Test plan

- [ ] Flux reconciles ArgoCD HelmRelease after merge
- [ ] Keycloak login succeeds for `xavier` without scope error
- [ ] `xavier` lands with admin role in ArgoCD
- [ ] Login survives pod restart